### PR TITLE
Adding entries for probes that already exist

### DIFF
--- a/baseline.md
+++ b/baseline.md
@@ -23,7 +23,7 @@ The Basleine is a set of security criteria that projects should meet to be consi
 | [OSPS-09](#osps-09) | 1 | Documentation | The project MUST have one or more mechanisms for public discussions about proposed [changes] and usage obstacles.  |
 | [OSPS-10](#osps-10) | 1 | Documentation | The [project documentation] MUST include an explanation of the contribution process.  |
 | [OSPS-11](#osps-11) | 1 | Documentation | The [project documentation] MUST provide user guides for all basic functionality.  |
-| [OSPS-12](#osps-12) | 0 | Quality | The project's source code MUST be publicly readable and have a static URL.  |
+| [OSPS-12](#osps-12) | 1 | Quality | The project's source code MUST be publicly readable and have a static URL.  |
 | [OSPS-13](#osps-13) | 1 | Quality | The [version control system] MUST contain a publicly readable record of all [changes] made, who made the [changes], and when the [changes] were made.  |
 | [OSPS-14](#osps-14) | 1 | Legal | The [version control system] MUST require all code [contributors] to assert that they are legally authorized to [commit] the associated contributions on every [commit].  |
 | [OSPS-15](#osps-15) | 1 | Legal | The [license] for the source code MUST be written in a standardized format approved by the OSI or FSF.  |
@@ -31,7 +31,7 @@ The Basleine is a set of security criteria that projects should meet to be consi
 | [OSPS-17](#osps-17) | 1 | Legal | The [license] for the [released software assets] MUST be written in a standardized format approved by the OSI or FSF, if different from the source code [license].  |
 | [OSPS-40](#osps-40) | 2 | Access Control | The project's permissions in [CI/CD pipelines] MUST be configured to the lowest available privileges except when explicitly elevated.  |
 | [OSPS-41](#osps-41) | 2 | Access Control | The [project documentation] MUST have a policy that code [contributors] are reviewed prior to granting escalated permissions to sensitive resources.  |
-| [OSPS-42](#osps-42) | 2 | Build & Release | All x MUST be created with consistent, automated [build and release pipelines].  |
+| [OSPS-42](#osps-42) | 2 | Build & Release | All [released software assets] MUST be created with consistent, automated [build and [release] pipelines].  |
 | [OSPS-43](#osps-43) | 2 | Build & Release | All [build and release pipelines] MUST use standardized tooling to ingest dependencies at build time.  |
 | [OSPS-44](#osps-44) | 2 | Build & Release | All [releases] MUST include a descriptive log of functional and security modifications.  |
 | [OSPS-45](#osps-45) | 2 | Documentation | The [project documentation] MUST include a policy for coordinated [vulnerability reporting], with a clear timeframe for response.  |
@@ -684,7 +684,7 @@ before being granted escalated permissions
 to sensitive resources, such as merge
 approval or access to secrets.
 
-It is recommended that, vetting includes
+It is recommended that vetting includes
 establishing a justifiable lineage of
 identity such as confirming the
 [contributor]'s association with a known
@@ -749,8 +749,8 @@ at build time.
 
 **Objective:**
 
-Ensure that the project's [build and release
-pipelines] use standardized tools and
+Ensure that the project's build and [release]
+pipelines use standardized tools and
 processes to manage dependencies, reducing
 the risk of compatibility issues or security
 vulnerabilities in the software.
@@ -1290,7 +1290,7 @@ Code provided by an external source that is
 executed by a system without validation or
 restriction.
 
-### Build and Release Pipelines
+### Build and Release Pipeline
 
 A series of automated processes that compile
 and deploy software. Similar to the generic
@@ -1523,7 +1523,8 @@ This baseline was created by community leaders from across the Linux Foundation,
 - Fintech Open Source Foundation (FINOS)
 
 [Arbitrary Code]: #arbitrary-code
-[Build and Release Pipelines]: #build-and-release-pipelines
+[Build and Release Pipeline]: #build-and-release-pipeline
+[build and release pipelines]: #build-and-release-pipeline
 [Change]: #change
 [changes]: #change
 [CI/CD Pipeline]: #ci/cd-pipeline

--- a/baseline.md
+++ b/baseline.md
@@ -31,7 +31,7 @@ The Basleine is a set of security criteria that projects should meet to be consi
 | [OSPS-17](#osps-17) | 1 | Legal | The [license] for the [released software assets] MUST be written in a standardized format approved by the OSI or FSF, if different from the source code [license].  |
 | [OSPS-40](#osps-40) | 2 | Access Control | The project's permissions in [CI/CD pipelines] MUST be configured to the lowest available privileges except when explicitly elevated.  |
 | [OSPS-41](#osps-41) | 2 | Access Control | The [project documentation] MUST have a policy that code [contributors] are reviewed prior to granting escalated permissions to sensitive resources.  |
-| [OSPS-42](#osps-42) | 2 | Build & Release | All [released software assets] MUST be created with consistent, automated [build and [release] pipelines].  |
+| [OSPS-42](#osps-42) | 2 | Build & Release | All [released software assets] MUST be created with consistent, automated [build and release pipelines].  |
 | [OSPS-43](#osps-43) | 2 | Build & Release | All [build and release pipelines] MUST use standardized tooling to ingest dependencies at build time.  |
 | [OSPS-44](#osps-44) | 2 | Build & Release | All [releases] MUST include a descriptive log of functional and security modifications.  |
 | [OSPS-45](#osps-45) | 2 | Documentation | The [project documentation] MUST include a policy for coordinated [vulnerability reporting], with a clear timeframe for response.  |
@@ -74,16 +74,16 @@ project's [version control system], requiring
 authentication when accessing sensitive data
 or modifying [repository] settings.
 
-**Control Mappings:**  
-  
+**Control Mappings:**
+
 _No control mappings identified._
 
-**Security Insights Value:**  
-  
+**Security Insights Value:**
+
 _No security insights identified._
 
-**Scorecard Probe:**  
-  
+**Scorecard Probe(s):**
+
 _No scorecard probe identified._
 
 ### OSPS-02
@@ -108,16 +108,16 @@ permissions to [collaborators] by default when
 added, granting additional permissions only
 when necessary.
 
-**Control Mappings:**  
-  
+**Control Mappings:**
+
 _No control mappings identified._
 
-**Security Insights Value:**  
-  
+**Security Insights Value:**
+
 _No security insights identified._
 
-**Scorecard Probe:**  
-  
+**Scorecard Probe(s):**
+
 _No scorecard probe identified._
 
 ### OSPS-03
@@ -143,17 +143,17 @@ requiring [changes] to be made through
 pull/merge requests or other review
 mechanisms.
 
-**Control Mappings:**  
-  
+**Control Mappings:**
+
 _No control mappings identified._
 
-**Security Insights Value:**  
-  
+**Security Insights Value:**
+
 _No security insights identified._
 
-**Scorecard Probe:**  
-  
-_No scorecard probe identified._
+**Scorecard Probe(s):**
+
+- blocksForcePushOnBranches
 
 ### OSPS-04
 
@@ -176,17 +176,17 @@ Set branch protection on the [primary branch]
 in the project's [version control system] to
 prevent deletion.
 
-**Control Mappings:**  
-  
+**Control Mappings:**
+
 _No control mappings identified._
 
-**Security Insights Value:**  
-  
+**Security Insights Value:**
+
 _No security insights identified._
 
-**Scorecard Probe:**  
-  
-_No scorecard probe identified._
+**Scorecard Probe(s):**
+
+- blocksDeleteOnBranches
 
 ### OSPS-05
 
@@ -209,17 +209,17 @@ Ensure that the project's build and [release]
 pipelines do not execute [arbitrary code]
 provided from external sources.
 
-**Control Mappings:**  
-  
+**Control Mappings:**
+
 _No control mappings identified._
 
-**Security Insights Value:**  
-  
+**Security Insights Value:**
+
 _No security insights identified._
 
-**Scorecard Probe:**  
-  
-_No scorecard probe identified._
+**Scorecard Probe(s):**
+
+- hasDangerousWorkflowScriptInjection
 
 ### OSPS-06
 
@@ -244,16 +244,16 @@ produced by the project, following a
 consistent naming convention or numbering
 scheme.
 
-**Control Mappings:**  
-  
+**Control Mappings:**
+
 _No control mappings identified._
 
-**Security Insights Value:**  
-  
+**Security Insights Value:**
+
 _No security insights identified._
 
-**Scorecard Probe:**  
-  
+**Scorecard Probe(s):**
+
 _No scorecard probe identified._
 
 ### OSPS-07
@@ -279,16 +279,16 @@ responses, and other services to use
 encrypted channels such as SSH or HTTPS for
 data transmission.
 
-**Control Mappings:**  
-  
+**Control Mappings:**
+
 _No control mappings identified._
 
-**Security Insights Value:**  
-  
+**Security Insights Value:**
+
 _No security insights identified._
 
-**Scorecard Probe:**  
-  
+**Scorecard Probe(s):**
+
 _No scorecard probe identified._
 
 ### OSPS-09
@@ -315,16 +315,16 @@ mailing lists, instant messaging, or issue
 trackers, to facilitate open communication
 and feedback.
 
-**Control Mappings:**  
-  
+**Control Mappings:**
+
 _No control mappings identified._
 
-**Security Insights Value:**  
-  
+**Security Insights Value:**
+
 _No security insights identified._
 
-**Scorecard Probe:**  
-  
+**Scorecard Probe(s):**
+
 _No scorecard probe identified._
 
 ### OSPS-10
@@ -349,16 +349,16 @@ process including the steps for submitting
 [changes], and engaging with the project
 maintainers.
 
-**Control Mappings:**  
-  
+**Control Mappings:**
+
 _No control mappings identified._
 
-**Security Insights Value:**  
-  
+**Security Insights Value:**
+
 _No security insights identified._
 
-**Scorecard Probe:**  
-  
+**Scorecard Probe(s):**
+
 _No scorecard probe identified._
 
 ### OSPS-11
@@ -384,16 +384,16 @@ use the project's features. If there are any
 known dangerous or destructive actions
 available, include highly-visible warnings.
 
-**Control Mappings:**  
-  
+**Control Mappings:**
+
 _No control mappings identified._
 
-**Security Insights Value:**  
-  
+**Security Insights Value:**
+
 _No security insights identified._
 
-**Scorecard Probe:**  
-  
+**Scorecard Probe(s):**
+
 _No scorecard probe identified._
 
 ### OSPS-12
@@ -420,16 +420,16 @@ documentation clarifies the primary source.
 Avoid frequent [changes] to the [repository]
 that would impact the [repository] URL.
 
-**Control Mappings:**  
-  
+**Control Mappings:**
+
 _No control mappings identified._
 
-**Security Insights Value:**  
-  
+**Security Insights Value:**
+
 _No security insights identified._
 
-**Scorecard Probe:**  
-  
+**Scorecard Probe(s):**
+
 _No scorecard probe identified._
 
 ### OSPS-13
@@ -456,16 +456,16 @@ Bitbucket to maintain a publicly readable
 [commits] in a way that would obscure the
 author of any [commits].
 
-**Control Mappings:**  
-  
+**Control Mappings:**
+
 _No control mappings identified._
 
-**Security Insights Value:**  
-  
+**Security Insights Value:**
+
 _No security insights identified._
 
-**Scorecard Probe:**  
-  
+**Scorecard Probe(s):**
+
 _No scorecard probe identified._
 
 ### OSPS-14
@@ -494,16 +494,16 @@ assert that they are legally authorized to
 [commit]. Use a [status check] to ensure the
 assertion is made.
 
-**Control Mappings:**  
-  
+**Control Mappings:**
+
 _No control mappings identified._
 
-**Security Insights Value:**  
-  
+**Security Insights Value:**
+
 _No security insights identified._
 
-**Scorecard Probe:**  
-  
+**Scorecard Probe(s):**
+
 _No scorecard probe identified._
 
 ### OSPS-15
@@ -530,17 +530,17 @@ approved by the Open Source Initiative (OSI)
 or Free Software Foundation (FSF), ensuring
 that the terms are clear and enforceable.
 
-**Control Mappings:**  
-  
+**Control Mappings:**
+
 _No control mappings identified._
 
-**Security Insights Value:**  
-  
+**Security Insights Value:**
+
 _No security insights identified._
 
-**Scorecard Probe:**  
-  
-_No scorecard probe identified._
+**Scorecard Probe(s):**
+
+- hasPermissiveLicense
 
 ### OSPS-16
 
@@ -565,17 +565,17 @@ the project's [LICENSE] file or [LICENSE]/
 directory to provide visibility and clarity
 on the licensing terms.
 
-**Control Mappings:**  
-  
+**Control Mappings:**
+
 _No control mappings identified._
 
-**Security Insights Value:**  
-  
+**Security Insights Value:**
+
 _No security insights identified._
 
-**Scorecard Probe:**  
-  
-_No scorecard probe identified._
+**Scorecard Probe(s):**
+
+- hasLicenseFile
 
 ### OSPS-17
 
@@ -606,16 +606,16 @@ Foundation (FSF).
 Only necessary if [license] is different
 from the source code [license].
 
-**Control Mappings:**  
-  
+**Control Mappings:**
+
 _No control mappings identified._
 
-**Security Insights Value:**  
-  
+**Security Insights Value:**
+
 _No security insights identified._
 
-**Scorecard Probe:**  
-  
+**Scorecard Probe(s):**
+
 _No scorecard probe identified._
 
 ### OSPS-40
@@ -646,17 +646,18 @@ may be possible at the organizational or
 [repository] level. If not, set permissions at
 the top level of the pipeline.
 
-**Control Mappings:**  
-  
+**Control Mappings:**
+
 _No control mappings identified._
 
-**Security Insights Value:**  
-  
+**Security Insights Value:**
+
 _No security insights identified._
 
-**Scorecard Probe:**  
-  
-_No scorecard probe identified._
+**Scorecard Probe(s):**
+
+- topLevelPermissions
+- jobLevelPermissions
 
 ### OSPS-41
 
@@ -690,16 +691,16 @@ identity such as confirming the
 [contributor]'s association with a known
 trusted organization.
 
-**Control Mappings:**  
-  
+**Control Mappings:**
+
 _No control mappings identified._
 
-**Security Insights Value:**  
-  
+**Security Insights Value:**
+
 _No security insights identified._
 
-**Scorecard Probe:**  
-  
+**Scorecard Probe(s):**
+
 _No scorecard probe identified._
 
 ### OSPS-42
@@ -722,21 +723,23 @@ and distribution of the software.
 
 Implement reproducible build and [release]
 pipelines for all software assets produced
-by the project. [VCS]-integrated pipelines are
+by the project. 
+
+[VCS]-integrated pipelines are
 recommended to ensure consistency and
 automation in the build and [release]
 processes.
 
-**Control Mappings:**  
-  
+**Control Mappings:**
+
 _No control mappings identified._
 
-**Security Insights Value:**  
-  
+**Security Insights Value:**
+
 _No security insights identified._
 
-**Scorecard Probe:**  
-  
+**Scorecard Probe(s):**
+
 _No scorecard probe identified._
 
 ### OSPS-43
@@ -765,16 +768,16 @@ dependency file, lock file, or manifest to
 specify the required dependencies, which are
 then pulled in by the build system.
 
-**Control Mappings:**  
-  
+**Control Mappings:**
+
 _No control mappings identified._
 
-**Security Insights Value:**  
-  
+**Security Insights Value:**
+
 _No security insights identified._
 
-**Scorecard Probe:**  
-  
+**Scorecard Probe(s):**
+
 _No scorecard probe identified._
 
 ### OSPS-44
@@ -803,16 +806,16 @@ beyond [commit] messages, such as descriptions
 of the security impact or relevance to
 different use cases.
 
-**Control Mappings:**  
-  
+**Control Mappings:**
+
 _No control mappings identified._
 
-**Security Insights Value:**  
-  
+**Security Insights Value:**
+
 _No security insights identified._
 
-**Scorecard Probe:**  
-  
+**Scorecard Probe(s):**
+
 _No scorecard probe identified._
 
 ### OSPS-45
@@ -841,17 +844,18 @@ vulnerabilities. Set expectations for the
 how the project will respond and address
 reported issues.
 
-**Control Mappings:**  
-  
+**Control Mappings:**
+
 _No control mappings identified._
 
-**Security Insights Value:**  
-  
+**Security Insights Value:**
+
 _No security insights identified._
 
-**Scorecard Probe:**  
-  
-_No scorecard probe identified._
+**Scorecard Probe(s):**
+
+- securityPolicyPresent
+- securityPolicyContainsVulnerabilityDisclosure
 
 ### OSPS-46
 
@@ -881,16 +885,16 @@ It is recommended that [project documentation]
 also sets expectations for how [defects] will
 be triaged and resolved.
 
-**Control Mappings:**  
-  
+**Control Mappings:**
+
 _No control mappings identified._
 
-**Security Insights Value:**  
-  
+**Security Insights Value:**
+
 _No security insights identified._
 
-**Scorecard Probe:**  
-  
+**Scorecard Probe(s):**
+
 _No scorecard probe identified._
 
 ### OSPS-47
@@ -922,16 +926,16 @@ It is recommended that this guide is the
 source of truth for both [contributors] and
 approvers.
 
-**Control Mappings:**  
-  
+**Control Mappings:**
+
 _No control mappings identified._
 
-**Security Insights Value:**  
-  
+**Security Insights Value:**
+
 _No security insights identified._
 
-**Scorecard Probe:**  
-  
+**Scorecard Probe(s):**
+
 _No scorecard probe identified._
 
 ### OSPS-48
@@ -958,16 +962,16 @@ that explains the actions and actors. Actors
 include any subsystem or entity that can
 influence another segment in the system.
 
-**Control Mappings:**  
-  
+**Control Mappings:**
+
 _No control mappings identified._
 
-**Security Insights Value:**  
-  
+**Security Insights Value:**
+
 _No security insights identified._
 
-**Scorecard Probe:**  
-  
+**Scorecard Probe(s):**
+
 _No scorecard probe identified._
 
 ### OSPS-49
@@ -1001,17 +1005,18 @@ This enables users to ingest this data in a
 standardized approach alongside other
 projects in their environment.
 
-**Control Mappings:**  
-  
+**Control Mappings:**
+
 _No control mappings identified._
 
-**Security Insights Value:**  
-  
+**Security Insights Value:**
+
 _No security insights identified._
 
-**Scorecard Probe:**  
-  
-_No scorecard probe identified._
+**Scorecard Probe(s):**
+
+- hasSBOM
+- hasReleaseSBOM
 
 ### OSPS-50
 
@@ -1043,17 +1048,17 @@ It is recommended that any non-blocking
 or fail requirement that approvers may be
 tempted to bypass.
 
-**Control Mappings:**  
-  
+**Control Mappings:**
+
 _No control mappings identified._
 
-**Security Insights Value:**  
-  
+**Security Insights Value:**
+
 _No security insights identified._
 
-**Scorecard Probe:**  
-  
-_No scorecard probe identified._
+**Scorecard Probe(s):**
+
+- runsStatusChecksBeforeMerging
 
 ### OSPS-51
 
@@ -1087,16 +1092,16 @@ lower standard if they have lower levels of
 adoption or are not intended for general
 use.
 
-**Control Mappings:**  
-  
+**Control Mappings:**
+
 _No control mappings identified._
 
-**Security Insights Value:**  
-  
+**Security Insights Value:**
+
 _No security insights identified._
 
-**Scorecard Probe:**  
-  
+**Scorecard Probe(s):**
+
 _No scorecard probe identified._
 
 ### OSPS-52
@@ -1125,17 +1130,17 @@ process such as testing, it should be stored
 in a separate [repository] and fetched during
 a specific well-documented pipeline step.
 
-**Control Mappings:**  
-  
+**Control Mappings:**
+
 _No control mappings identified._
 
-**Security Insights Value:**  
-  
+**Security Insights Value:**
+
 _No security insights identified._
 
-**Scorecard Probe:**  
-  
-_No scorecard probe identified._
+**Scorecard Probe(s):**
+
+- hasBinaryArtifacts
 
 ### OSPS-70
 
@@ -1163,16 +1168,16 @@ alternatives include hardware tokens, mobile
 authenticator apps, or biometric
 authentication.
 
-**Control Mappings:**  
-  
+**Control Mappings:**
+
 _No control mappings identified._
 
-**Security Insights Value:**  
-  
+**Security Insights Value:**
+
 _No security insights identified._
 
-**Scorecard Probe:**  
-  
+**Scorecard Probe(s):**
+
 _No scorecard probe identified._
 
 ### OSPS-71
@@ -1200,16 +1205,16 @@ results before any [release], and add status
 checks that verify compliance with that 
 policy prior to [release].
 
-**Control Mappings:**  
-  
+**Control Mappings:**
+
 _No control mappings identified._
 
-**Security Insights Value:**  
-  
+**Security Insights Value:**
+
 _No security insights identified._
 
-**Scorecard Probe:**  
-  
+**Scorecard Probe(s):**
+
 _No scorecard probe identified._
 
 ### OSPS-72
@@ -1237,16 +1242,16 @@ vulnerabilities, fixing exploitable
 vulnerabilities, and verifying unexploitable
 vulnerabilities.
 
-**Control Mappings:**  
-  
+**Control Mappings:**
+
 _No control mappings identified._
 
-**Security Insights Value:**  
-  
+**Security Insights Value:**
+
 _No security insights identified._
 
-**Scorecard Probe:**  
-  
+**Scorecard Probe(s):**
+
 _No scorecard probe identified._
 
 ### OSPS-73
@@ -1272,18 +1277,20 @@ the [released software assets], explaining how
 users can interact with the software and
 what data is expected or produced.
 
-**Control Mappings:**  
-  
+**Control Mappings:**
+
 _No control mappings identified._
 
-**Security Insights Value:**  
-  
+**Security Insights Value:**
+
 _No security insights identified._
 
-**Scorecard Probe:**  
-  
+**Scorecard Probe(s):**
+
 _No scorecard probe identified._
+
 ## Lexicon
+
 ### Arbitrary Code
 
 Code provided by an external source that is

--- a/baseline.yaml
+++ b/baseline.yaml
@@ -248,6 +248,7 @@ criteria:
     security_insights_value: # TODO
     scorecard_probe: # TODO
   - id: OSPS-12
+    maturity_level: 1
     category: Quality
     criteria: |
       The project's source code MUST be publicly

--- a/baseline.yaml
+++ b/baseline.yaml
@@ -62,7 +62,8 @@ criteria:
       or modifying repository settings.
     control_mappings: # TODO
     security_insights_value: # TODO
-    scorecard_probe: # TODO
+    scorecard_probe:
+      - # None yet
   - id: OSPS-02
     maturity_level: 1
     category: Access Control
@@ -82,7 +83,8 @@ criteria:
       when necessary.
     control_mappings: # TODO
     security_insights_value: # TODO
-    scorecard_probe: # TODO
+    scorecard_probe:
+      - # None yet
   - id: OSPS-03
     maturity_level: 1
     category: Access Control
@@ -102,8 +104,8 @@ criteria:
       pull/merge requests or other review
       mechanisms.
     control_mappings: # TODO
-    security_insights_value: # TODO
-    scorecard_probe: # TODO
+    scorecard_probe:
+      - blocksForcePushOnBranches
   - id: OSPS-04
     maturity_level: 1
     category: Access Control
@@ -121,8 +123,8 @@ criteria:
       in the project's version control system to
       prevent deletion.
     control_mappings: # TODO
-    security_insights_value: # TODO
-    scorecard_probe: # TODO
+    scorecard_probe:
+      - blocksDeleteOnBranches
   - id: OSPS-05
     maturity_level: 1
     category: Build & Release
@@ -140,10 +142,10 @@ criteria:
       pipelines do not execute arbitrary code
       provided from external sources.
     control_mappings: # TODO
-    security_insights_value: # TODO
-    scorecard_probe: # TODO
+    scorecard_probe:
+      - hasDangerousWorkflowScriptInjection
   - id: OSPS-06
-    maturity_level: 1
+    maturity_level: 1 # TODO: This should be lv2
     category: Build & Release
     criteria: |
       All releases and released software assets
@@ -162,7 +164,8 @@ criteria:
       scheme.
     control_mappings: # TODO
     security_insights_value: # TODO
-    scorecard_probe: # TODO
+    scorecard_probe:
+      - # None, would need to be paired with SI
   - id: OSPS-07
     maturity_level: 1
     category: Build & Release
@@ -183,7 +186,8 @@ criteria:
       data transmission.
     control_mappings: # TODO
     security_insights_value: # TODO
-    scorecard_probe: # TODO
+    scorecard_probe:
+      - # None, would need to be paired with SI
   - id: OSPS-09
     maturity_level: 1
     category: Documentation
@@ -205,7 +209,8 @@ criteria:
       and feedback.
     control_mappings: # TODO
     security_insights_value: # TODO
-    scorecard_probe: # TODO
+    scorecard_probe:
+      - # None yet
   - id: OSPS-10
     maturity_level: 1
     category: Documentation
@@ -225,7 +230,8 @@ criteria:
       maintainers.
     control_mappings: # TODO
     security_insights_value: # TODO
-    scorecard_probe: # TODO
+    scorecard_probe:
+      - # None, may not be suitable
   - id: OSPS-11
     maturity_level: 1
     category: Documentation
@@ -246,7 +252,6 @@ criteria:
       available, include highly-visible warnings.
     control_mappings: # TODO
     security_insights_value: # TODO
-    scorecard_probe: # TODO
   - id: OSPS-12
     maturity_level: 1
     category: Quality
@@ -268,7 +273,6 @@ criteria:
       that would impact the repository URL.
     control_mappings: # TODO
     security_insights_value: # TODO
-    scorecard_probe: # TODO
   - id: OSPS-13
     maturity_level: 1
     category: Quality
@@ -290,7 +294,6 @@ criteria:
       author of any commits.
     control_mappings: # TODO
     security_insights_value: # TODO
-    scorecard_probe: # TODO
   - id: OSPS-14
     maturity_level: 1
     category: Legal
@@ -314,7 +317,8 @@ criteria:
       assertion is made.
     control_mappings: # TODO
     security_insights_value: # TODO
-    scorecard_probe: # TODO
+    scorecard_probe:
+      - # None, may not be suitable
   - id: OSPS-15
     maturity_level: 1
     category: Legal
@@ -336,7 +340,8 @@ criteria:
       that the terms are clear and enforceable.
     control_mappings: # TODO
     security_insights_value: # TODO
-    scorecard_probe: # TODO
+    scorecard_probe:
+      - hasPermissiveLicense # Check this
   - id: OSPS-16
     maturity_level: 1
     category: Legal
@@ -357,7 +362,8 @@ criteria:
       on the licensing terms.
     control_mappings: # TODO
     security_insights_value: # TODO
-    scorecard_probe: # TODO
+    scorecard_probe:
+      - hasLicenseFile
   - id: OSPS-17
     maturity_level: 1
     category: Legal
@@ -384,7 +390,8 @@ criteria:
       from the source code license.
     control_mappings: # TODO
     security_insights_value: # TODO
-    scorecard_probe: # TODO
+    scorecard_probe:
+      - # None, may need to be paired with SI
   - id: OSPS-40
     maturity_level: 2
     category: Access Control
@@ -409,8 +416,9 @@ criteria:
       repository level. If not, set permissions at
       the top level of the pipeline.
     control_mappings: # TODO
-    security_insights_value: # TODO
-    scorecard_probe: # TODO
+    scorecard_probe:
+      - topLevelPermissions
+      - jobLevelPermissions
   - id: OSPS-41
     maturity_level: 2
     category: Access Control
@@ -440,7 +448,6 @@ criteria:
       trusted organization.
     control_mappings: # TODO
     security_insights_value: # TODO
-    scorecard_probe: # TODO
   - id: OSPS-42
     maturity_level: 2
     category: Build & Release
@@ -457,13 +464,14 @@ criteria:
     implementation: |
       Implement reproducible build and release
       pipelines for all software assets produced
-      by the project. VCS-integrated pipelines are
+      by the project. 
+      
+      VCS-integrated pipelines are
       recommended to ensure consistency and
       automation in the build and release
       processes.
     control_mappings: # TODO
     security_insights_value: # TODO
-    scorecard_probe: # TODO
   - id: OSPS-43
     maturity_level: 2
     category: Build & Release
@@ -487,7 +495,8 @@ criteria:
       then pulled in by the build system.
     control_mappings: # TODO
     security_insights_value: # TODO
-    scorecard_probe: # TODO
+    scorecard_probe:
+      - # TODO
   - id: OSPS-44
     maturity_level: 2
     category: Build & Release
@@ -511,7 +520,8 @@ criteria:
       different use cases.
     control_mappings: # TODO
     security_insights_value: # TODO
-    scorecard_probe: # TODO
+    scorecard_probe:
+      - # TODO, this might be possible if paired with SI to find the release location
   - id: OSPS-45
     maturity_level: 2
     category: Documentation
@@ -535,7 +545,9 @@ criteria:
       reported issues.
     control_mappings: # TODO
     security_insights_value: # TODO
-    scorecard_probe: # TODO
+    scorecard_probe:
+      - securityPolicyPresent
+      - securityPolicyContainsVulnerabilityDisclosure
   - id: OSPS-46
     maturity_level: 2
     category: Documentation
@@ -561,7 +573,6 @@ criteria:
       be triaged and resolved.
     control_mappings: # TODO
     security_insights_value: # TODO
-    scorecard_probe: # TODO
   - id: OSPS-47
     maturity_level: 2
     category: Documentation
@@ -588,7 +599,6 @@ criteria:
       approvers.
     control_mappings: # TODO
     security_insights_value: # TODO
-    scorecard_probe: # TODO
   - id: OSPS-48
     maturity_level: 2
     category: Documentation
@@ -610,7 +620,6 @@ criteria:
       influence another segment in the system.
     control_mappings: # TODO
     security_insights_value: # TODO
-    scorecard_probe: # TODO
   - id: OSPS-49
     maturity_level: 2
     category: Quality
@@ -639,7 +648,11 @@ criteria:
       projects in their environment.
     control_mappings: # TODO
     security_insights_value: # TODO
-    scorecard_probe: # TODO
+    scorecard_probe:
+      - hasSBOM
+      - hasReleaseSBOM
+      - # TODO: check for non-sbom dependency files
+
   - id: OSPS-50
     maturity_level: 2
     category: Quality
@@ -667,7 +680,9 @@ criteria:
       tempted to bypass.
     control_mappings: # TODO
     security_insights_value: # TODO
-    scorecard_probe: # TODO
+    scorecard_probe:
+      - runsStatusChecksBeforeMerging
+      - # TODO: check for checks passing?
   - id: OSPS-51
     maturity_level: 2
     category: Quality
@@ -697,7 +712,8 @@ criteria:
       use.
     control_mappings: # TODO
     security_insights_value: # TODO
-    scorecard_probe: # TODO
+    scorecard_probe:
+      - # TODO, this may be possible if paired with SI to find the subproject
   - id: OSPS-52
     maturity_level: 2
     category: Quality
@@ -720,6 +736,8 @@ criteria:
       in a separate repository and fetched during
       a specific well-documented pipeline step.
     control_mappings: # TODO
+    scorecard_probe:
+      - hasBinaryArtifacts
   - id: OSPS-70
     maturity_level: 3
     category: Access Control
@@ -743,7 +761,8 @@ criteria:
       authentication.
     control_mappings: # TODO
     security_insights_value: # TODO
-    scorecard_probe: # TODO
+    scorecard_probe:
+      - # TODO
   - id: OSPS-71
     maturity_level: 3
     category: Build & Release
@@ -766,7 +785,8 @@ criteria:
       policy prior to release.
     control_mappings: # TODO
     security_insights_value: # TODO
-    scorecard_probe: # TODO
+    scorecard_probe:
+      - # TODO: this is about policy, but we should also look for evidence of SCA
   - id: OSPS-72
     maturity_level: 3
     category: Documentation
@@ -789,7 +809,6 @@ criteria:
       vulnerabilities.
     control_mappings: # TODO
     security_insights_value: # TODO
-    scorecard_probe: # TODO
   - id: OSPS-73
     maturity_level: 3
     category: Documentation
@@ -810,7 +829,6 @@ criteria:
       what data is expected or produced.
     control_mappings: # TODO
     security_insights_value: # TODO
-    scorecard_probe: # TODO
 
 # # # #
 #

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -16,15 +16,15 @@ import (
 
 // Struct for representing each criteria entry
 type Criteria struct {
-	ID                    string `yaml:"id"`
-	MaturityLevel         int    `yaml:"maturity_level"`
-	Category              string `yaml:"category"`
-	CriteriaText          string `yaml:"criteria"`
-	Objective             string `yaml:"objective"`
-	Implementation        string `yaml:"implementation"`
-	ControlMappings       string `yaml:"control_mappings"`
-	SecurityInsightsValue string `yaml:"security_insights_value"`
-	ScorecardProbe        string `yaml:"scorecard_probe"`
+	ID                    string   `yaml:"id"`
+	MaturityLevel         int      `yaml:"maturity_level"`
+	Category              string   `yaml:"category"`
+	CriteriaText          string   `yaml:"criteria"`
+	Objective             string   `yaml:"objective"`
+	Implementation        string   `yaml:"implementation"`
+	ControlMappings       string   `yaml:"control_mappings"`
+	SecurityInsightsValue string   `yaml:"security_insights_value"`
+	ScorecardProbe        []string `yaml:"scorecard_probe"`
 }
 
 // Struct for holding the entire YAML structure

--- a/cmd/template.md
+++ b/cmd/template.md
@@ -33,30 +33,32 @@ The Basleine is a set of security criteria that projects should meet to be consi
 **Implementation:**
 
 {{ .Implementation | addLinks }}
-**Control Mappings:**  
-{{ if .ControlMappings }}  
-{{ .ControlMappings }}  
-{{ else }}  
-_No control mappings identified._  
+**Control Mappings:**
+{{ if .ControlMappings }}
+{{ .ControlMappings }}
+{{ else }}
+_No control mappings identified._
 {{- end }}
 
-**Security Insights Value:**  
-{{ if .SecurityInsightsValue }}  
-{{ .SecurityInsightsValue }}  
-{{ else }}  
-_No security insights identified._  
+**Security Insights Value:**
+{{ if .SecurityInsightsValue }}
+{{ .SecurityInsightsValue }}
+{{ else }}
+_No security insights identified._
 {{- end }}
 
-**Scorecard Probe:**  
-{{ if .ScorecardProbe }}  
-{{ .ScorecardProbe }}  
-{{ else }}  
-_No scorecard probe identified._  
+**Scorecard Probe(s):**
+{{ if .ScorecardProbe }}
+{{- range .ScorecardProbe }}
+- {{ . }}
+{{- end }}
+{{- else }}
+_No scorecard probe identified._
 {{- end }}
 {{- end }}
+
 ## Lexicon
-
-{{- range .Lexicon }}
+{{ range .Lexicon }}
 ### {{ .Term }}
 
 {{ .Definition }}


### PR DESCRIPTION
Also added notes for places where we making probes might not be straightforward, and removed the key for probe or security insights in places where that key definitely isn't needed.

Also updated the template to handle one or multiple probes. And incidentally fixed some trailing spaces.