### PR TITLE
fix: clarify definition of a Collaborator

### DIFF
--- a/baseline.md
+++ b/baseline.md
@@ -1347,8 +1347,7 @@ the primary deliverable in a release.
 ### Collaborator
 
 A user with access to the project's version
-control system who can commit to the
-codebase, approve changes, or manage the
+control system who can approve changes, or manage the
 repository settings. Collaborators may have
 varying permission levels based on their role
 in the project.

--- a/baseline.md
+++ b/baseline.md
@@ -1346,11 +1346,14 @@ the primary deliverable in a release.
 
 ### Collaborator
 
-A user with access to the project's version
-control system who can approve changes, or manage the
-repository settings. Collaborators may have
-varying permission levels based on their role
-in the project.
+A user with a role on the project's version
+control system who can approve changes or
+manage the repository settings. Collaborators
+may have varying permission levels based on
+their role in the project. This does not
+include contributors whose changes only
+originate through a request from a repository
+fork.
 
 ### Commit
 

--- a/baseline.yaml
+++ b/baseline.yaml
@@ -881,12 +881,14 @@ lexicon:
       the primary deliverable in a release.
   - term: Collaborator
     definition: |
-      A user with access to the project's version
-      control system who can commit to the
-      codebase, approve changes, or manage the
-      repository settings. Collaborators may have
-      varying permission levels based on their role
-      in the project.
+      A user with a role on the project's version
+      control system who can approve changes or
+      manage the repository settings. Collaborators
+      may have varying permission levels based on
+      their role in the project. This does not
+      include contributors whose changes only
+      originate through a request from a repository
+      fork.
   - term: Commit
     definition: |
       A record of a single change submitted to the


### PR DESCRIPTION
MFA could not be enforced on committers that contribute to a PR that originates from a Fork.

@eddie-knight 