### PR TITLE
Allow usual LICENSE file names

### DIFF
--- a/baseline.yaml
+++ b/baseline.yaml
@@ -357,9 +357,11 @@ criteria:
       shared.
     implementation: |
       Include the project's source code license in
-      the project's LICENSE file or LICENSE/
+      the project's LICENSE file, COPYING file,
+      or LICENSE/
       directory to provide visibility and clarity
-      on the licensing terms.
+      on the licensing terms. The filename MAY
+      have an extension.
     control_mappings: # TODO
     security_insights_value: # TODO
     scorecard_probe:


### PR DESCRIPTION
Allow the name "COPYING" for the license filename
as recommended by FSF in
<https://www.gnu.org/licenses/gpl-howto.en.html>

Also allow filename extensions. Filename extensions are *widely* used in practice. LICENSE.md, LICENSE.txt, COPYING.txt, and even COPYING.LESSER are often seen projects.

Licensee (used by GitHub) can handle far more. See: https://github.com/licensee/licensee/blob/main/docs/what-we-look-at.md