### PR TITLE
Make the licensing text more precise

### DIFF
--- a/baseline.yaml
+++ b/baseline.yaml
@@ -387,8 +387,8 @@ criteria:
       providing clarity on how the code
       can be used and shared by others.
     implementation: |
-      Add a LICENSE file to the project's repo
-      with a license that is
+      If a different license is included with
+      released software assets, ensure it is
       an approved license by the
       Open Source Initiative (OSI), or
       a free license as approved by the

--- a/baseline.yaml
+++ b/baseline.yaml
@@ -323,21 +323,30 @@ criteria:
     maturity_level: 1
     category: Legal
     criteria: |
-      The license for the source code MUST be
-      written in a standardized format approved by
-      the OSI or FSF.
+      The license for the source code MUST
+      meet the OSI Open Source Definition or
+      the FSF Free Software Definition.
     objective: |
       Ensure that the project's source code is
       distributed under a recognized and legally
-      enforceable license, providing clarity on
-      how the code can be used and shared by
-      others.
+      enforceable open source software license,
+      providing clarity on how the code
+      can be used and shared by others.
     implementation: |
       Add a LICENSE file to the project's repo
-      that is written in a standardized format
-      approved by the Open Source Initiative (OSI)
-      or Free Software Foundation (FSF), ensuring
-      that the terms are clear and enforceable.
+      with a license that is
+      an approved license by the
+      Open Source Initiative (OSI), or
+      a free license as approved by the
+      Free Software Foundation (FSF).
+      Examples of such licenses include the
+      MIT, BSD 2-clause, BSD 3-clause revised,
+      Apache 2.0, Lesser GNU General Public
+      License (LGPL), and the
+      GNU General Public License (GPL).
+      Releasing to the public domain (e.g., CC0)
+      meets this criterion if there are no
+      other encumbrances (e.g., patents).
     control_mappings: # TODO
     security_insights_value: # TODO
     scorecard_probe:
@@ -369,25 +378,29 @@ criteria:
     category: Legal
     criteria: |
       The license for the released software assets
-      MUST be written in a standardized format
-      approved by the OSI or FSF, if different
-      from the source code license.
+      MUST meet the OSI Open Source Definition or
+      the FSF Free Software Definition.
     objective: |
-      Ensure that the project's released software
-      assets are distributed under a recognized
-      and legally enforceable license, separate
-      from the source code license if necessary,
-      providing clarity on how the software can be
-      used and shared.
+      Ensure that the project's source code is
+      distributed under a recognized and legally
+      enforceable open source software license,
+      providing clarity on how the code
+      can be used and shared by others.
     implementation: |
-      Choose a license for the project's released
-      software assets that is written in a
-      standardized format approved by the Open
-      Source Initiative (OSI) or Free Software
-      Foundation (FSF).
-
-      Only necessary if license is different
-      from the source code license.
+      Add a LICENSE file to the project's repo
+      with a license that is
+      an approved license by the
+      Open Source Initiative (OSI), or
+      a free license as approved by the
+      Free Software Foundation (FSF).
+      Examples of such licenses include the
+      MIT, BSD 2-clause, BSD 3-clause revised,
+      Apache 2.0, Lesser GNU General Public
+      License (LGPL), and the
+      GNU General Public License (GPL).
+      Note that the license for the released
+      software assets may be different than the
+      source code.
     control_mappings: # TODO
     security_insights_value: # TODO
     scorecard_probe:


### PR DESCRIPTION
This makes it more clear exactly what licenses
are allowed, by saying "OSI Open Source Definition and the FSF Free Software Definition" instead of a vague statement about OSI and FSF (which is too vague).

I included specific examples, because that should immediately answer questions for most people (so they don't have to look up anything). I added a note about releasing to the public domain, which includes CC0 and software written by US government employees. OSI won't just say CC0 is okay, in part because it's a partial license and it's possible for a program to be released under CC0 while the releaser holds on to patents. But it *does* meet the definition in the usual case where there are no patents being withheld.

This text is based on:
https://www.bestpractices.dev/en/criteria/0?details=true&rationale=true#0.floss_license

However, that text also allows Debian and Fedora to decide. Others seemed uncomfortable with that, and Eddie seemed to want this text to look like this instead of like the best practices badge text, so here's an attempt to address that.