### PR TITLE
Update maintainers from Kusari

### DIFF
--- a/governance/MAINTAINERS.md
+++ b/governance/MAINTAINERS.md
@@ -3,13 +3,13 @@
 ## Project Maintainers
 
 - Eddie Knight, Sonatype (@eddie-knight)
-- Michael Lieberman, Kusari (@mlieberman85)
 - Adolfo García Veytia, Stacklok (@puerco)
 - Christopher "CRob" Robinson, OpenSSF (@SecurityCRob)
 - David A Wheeler, OpenSSF (@david-a-wheeler)
+- Ben Cotton, Kusari (@funnelfiasco)
 
 ## Emeritus Maintainers
 
-- None
+- Michael Lieberman, Kusari (@mlieberman85)
 
 Additions and status changes may be made via the processes outlined in the [governance](/GOVERNANCE.md) document.


### PR DESCRIPTION
Add me and move Mike to emeritus status.

Rules lawyering™: This is not a self-nomination (I do not meet the requirements for that), just me taking the initiative to implement what a "[sponsoring committee](https://github.com/ossf/security-baseline/blob/main/governance/GOVERNANCE.md#sponsoring-committees)" agreed to in previous working group calls. 😄  