### PR TITLE
Clarify OSPS-BR-01 to better express the intent

### DIFF
--- a/baseline.yaml
+++ b/baseline.yaml
@@ -197,7 +197,7 @@ criteria:
     category: Build & Release
     criteria: |
       Build and release pipelines MUST only execute
-      code that's present in the repository *or* from external trusted sources.
+      code that's either present in the repository *or* from external sources trusted by the project.
     objective: |
       Reduce the risk of code injection or other
       security vulnerabilities in the project's

--- a/baseline.yaml
+++ b/baseline.yaml
@@ -196,8 +196,8 @@ criteria:
     maturity_level: 1
     category: Build & Release
     criteria: |
-      Build and release pipelines MUST NOT execute
-      untrusted code.
+      Build and release pipelines MUST only execute
+      code that's present in the repository *or* from external trusted sources.
     objective: |
       Reduce the risk of code injection or other
       security vulnerabilities in the project's

--- a/baseline.yaml
+++ b/baseline.yaml
@@ -196,18 +196,24 @@ criteria:
     maturity_level: 1
     category: Build & Release
     criteria: |
-      The project's build and release pipelines
-      MUST NOT execute arbitrary code that is
-      input from outside of the build script.
+      Build and release pipelines MUST NOT execute
+      untrusted code.
     objective: |
       Reduce the risk of code injection or other
       security vulnerabilities in the project's
       build and release processes by restricting
-      the execution of external code.
+      the execution of external code in workflows.
     implementation: |
       Ensure that the project's build and release
-      pipelines do not execute arbitrary code
-      provided from external sources.
+      pipelines do not execute untrusted code
+      provided from external sources. Maintainers
+      may establish trust in a variety of ways,
+      including digital signature verification and
+      inspection of external code. For clarity,
+      this criterion does not prohibit the use of
+      software in a package format that executes
+      scripts (e.g. RPM, .deb) so long as the
+      package itself is trusted.
     control_mappings: # TODO
     scorecard_probe:
       - hasDangerousWorkflowScriptInjection


### PR DESCRIPTION
This is my own attempt at #63. It differs from @david-a-wheeler's #103 by:

* Keeping the criterion inclusive of build pipelines. 
* Explicitly calling out that we do not mean to prohibit the use of RPM, deb, etc.

It does include some edits from David's PR as well.