### PR TITLE
Add minder OSPS minder profiles and first rules

### DIFF
--- a/resources/minder/README.md
+++ b/resources/minder/README.md
@@ -1,0 +1,85 @@
+# OSPS Minder Profiles
+
+[Minder](https://github.com/mindersec/minder) is an Open Source Supply Chain
+Security plaform part of the OpenSSF ecosystem. A Minder profile is a security
+policy that groups together rules that are constantly evaluating against entities
+in your software project.
+
+This directory contains three [Minder](https://github.com/mindersec/minder) 
+profiles that any project can use to monitor its compliance with the 
+Open Source Project Security Baseline.
+
+Each file is designed to be applied incrementally: Projects at Level 1 
+(sandbox or similar) should only apply the Level 1 file, projects on Level 2 
+(incubating or similar) should apply Level 1 and Level 2 and at Level 3
+you should apply all files.
+
+## Installing
+
+To install the profiles and monitor a project using the public Minder instance,
+follow these steps:
+
+1. Install the Minder CLI
+1. Login using your GitHub account
+1. Enroll the GitHub provider in your project
+1. Apply the profile and all the OSPS rule types.
+
+### Detailed instructions
+
+These are installation steps in full detail. If you run into a problem, see
+the section on getting help below. The following commands need to be run
+in a computer with a web browser installed.
+
+#### 1. Install the Minder CLI
+
+Follow the 
+[instructions on the Minder README](https://github.com/mindersec/minder#installation) 
+to install the `minder` CLI in your computer.
+
+#### 2. Log In With Your GitHub Account
+
+Run the following commands to authenticate:
+
+```
+minder auth login
+```
+
+Follow the authentication flow to log in. This will create your first (empty)
+project.
+
+#### 3. Enroll the GitHub Provider in your Project.
+
+```bash
+minder provider enroll
+```
+
+Follow the GitHub authentication flow to connect minder to your GitHub organization
+
+#### 4. Apply the OSPS Profile(s) and Rule Types
+
+Finally, apply the appropiate profiles according to you project's maturity level
+and the OSPS rule types. 
+
+Clone the OSPS Baseline repository and apply the minder resource files: 
+
+```bash
+git clone git@github.com:ossf/security-baseline.git
+
+cd security-baseline
+
+minder ruletype apply -f resources/minder/rules/
+
+minder profile apply -f resources/minder/osps-baseline-level1.yaml
+```
+
+Remember to install the profile for your level and all the previous ones.
+For example, if your project is on maturity level 3 (graduated or similar), 
+apply the Level 3 profile, but also 1 & 2.
+
+## Help and Support
+
+If you have questions or need help, please talk to the Minder maintainers in
+[#minder in OpenSSF Slack](https://openssf.slack.com/archives/C07SP9RSM2L) 
+([get an invite here](https://openssf.org/getinvolved/) if you are not on it
+yet). We would love to hear your experience as the project evolves to help you
+monitor and remediate the OSPS Baseline checks.

--- a/resources/minder/data-sources/ghapi.yaml
+++ b/resources/minder/data-sources/ghapi.yaml
@@ -1,0 +1,16 @@
+version: v1
+type: data-source
+name: ghapi
+context: {}
+rest:
+  def:
+    license:
+      endpoint: https://api.github.com/repos/{owner}/{repo}/license
+      parse: json
+      input_schema:
+        type: object
+        properties:
+          owner:
+            type: string
+          repo:
+            type: string

--- a/resources/minder/data-sources/security-insights.yaml
+++ b/resources/minder/data-sources/security-insights.yaml
@@ -1,0 +1,23 @@
+---
+# NOTICE: THIS DATA SOURCE IS EXPERIMENTAL
+#
+# This is an experimental data source that loads the contents of
+# a repo's Security Insights file (https://github.com/ossf/security-insights-spec)
+# and exposes it to the rule evaluation engine.
+version: v1
+type: data-source
+name: securityinsights
+context: {
+ project_id: "29e9eb67-b8dd-49aa-966a-8d691d36799b"
+ }
+structured:
+  def:
+    "parse":
+      path:
+        file_name: SECURITY-INSIGHTS.yaml
+        alternatives:
+        - "SECURITY-INSIGHTS.yml"
+        - "security-insights.yaml"
+        - "security-insights.yml"
+        - "SECURITY_INSIGHTS.yaml"
+        - "SECURITY_INSIGHTS.yml"

--- a/resources/minder/data-sources/spdx-license-list.yaml
+++ b/resources/minder/data-sources/spdx-license-list.yaml
@@ -1,0 +1,10 @@
+version: v1
+type: data-source
+name: spdx-license-list
+context: {}
+rest:
+  def:
+    licenses:
+      endpoint: https://raw.githubusercontent.com/spdx/license-list-data/refs/heads/main/json/licenses.json
+      parse: json
+      input_schema: {}

--- a/resources/minder/osps-baseline-level1.yaml
+++ b/resources/minder/osps-baseline-level1.yaml
@@ -50,14 +50,14 @@ repository:
   #   displayName: "[OSPS-AC-03] Prevent commits to main without a pull request"
   #   def: # TODO
 
-  # - name: OSPS-AC-04
-  #   Branch Prevent deletion of main branch
-  #
-  #   [] Check GitHub's branch protection config blocks deletin main branch
-  #
-  #   type: # TODO
-  #   displayName: "[OSPS-AC-04] Prevent deletion of main branch"
-  #   def: # TODO
+  - name: OSPS-AC-04
+    #   Branch Prevent deletion of main branch
+    #
+    #   [x] Check GitHub's branch protection config blocks deletin main branch
+    #
+    type: OSPS-AC-04
+    displayName: "[OSPS-AC-04] Prevent deletion of main branch"
+    def: {}
 
   # - name: OSPS-BR-01
   #   Build and release pipelines MUST NOT execute arbitrary code 

--- a/resources/minder/osps-baseline-level1.yaml
+++ b/resources/minder/osps-baseline-level1.yaml
@@ -101,6 +101,26 @@ repository:
     type: OSPS-DO-02
     def: {}
 
+  - name: OSPS-LE-02
+  #   The license for the source code MUST meet the OSI Open Source
+  #   Definition or the FSF Free Software Definition.
+  #
+  #   [X] Check repo detected license against OSI and FSF approved ones
+  #
+    type: OSPS-LE-02
+    def: {}
+
+  - name: OSPS-LE-03
+  #   The license for the source code MUST be maintained in a standard
+  #   location within the project’s repository.
+  #
+  #   [X] Check repo for LICENSE file
+  #   [X] Check repo for COPYING file
+  #   [X] Check repo for LICENSE/ folder
+  #
+    type: OSPS-LE-03
+    def: {}
+
   # - name: OSPS-QA-01
   #   Source code MUST be publicly readable and have a static URL
   #

--- a/resources/minder/osps-baseline-level1.yaml
+++ b/resources/minder/osps-baseline-level1.yaml
@@ -1,0 +1,118 @@
+# SPDX-FileCopyrightText: Copyright 2024 The OSPS Baseline Authors
+# SPDX-License-Identifier: Apache-2.0
+---
+# This file is part of a set of Minder security profiles to check a project's
+# compliance with the OSPS Baseline controls.
+#
+# This profiles, as the Baseline itself, are under active development
+# feel free to try them out but expect constant changes as the baseline
+# an support in Minder evolves.
+#
+# For more information about Minder to use this profie, check out the
+# project's documentation at https://github.com/mindersec/minder  
+
+
+version: v1
+type: profile
+name: osps_baseline_l1
+display_name: OSPS Baseline - Level 1
+context:
+  provider: github
+alert: "on"
+remediate: "off"
+
+
+# Checks that require data from the repo
+repository:
+  # - name: OSPS-AC-01
+  #   The project’s version control system MUST require multi-factor authentication
+  #
+  #   [] Check th github organization setting to esure 2fa is enabled
+  #
+  #   type: # TODO
+  #   def: # TODO
+
+  # - name: OSPS-AC-02
+  #   Version control system MUST restrict collaborator permissions to the lowest
+  #
+  #   TBD
+  #
+  #   available privileges by default.
+  #   type: # TODO
+  #   def: # TODO
+
+  # - name: OSPS-AC-03
+  #   Branch protecton (push)
+  #
+  #   [] Check GitHub's branch protection setting prevent direct pushes to main/master
+  #
+  #   type: TODO
+  #   displayName: "[OSPS-AC-03] Prevent commits to main without a pull request"
+  #   def: # TODO
+
+  # - name: OSPS-AC-04
+  #   Branch Prevent deletion of main branch
+  #
+  #   [] Check GitHub's branch protection config blocks deletin main branch
+  #
+  #   type: # TODO
+  #   displayName: "[OSPS-AC-04] Prevent deletion of main branch"
+  #   def: # TODO
+
+  # - name: OSPS-BR-01
+  #   Build and release pipelines MUST NOT execute arbitrary code 
+  #
+  #   TBD
+  #
+  #   type: # TODO
+  #   def: # TODO
+
+  # - name: OSPS-BR-02
+  #   All releases MUST be assigned a unique version identifier
+  #
+  #   [] Check the release entity for an associtated version label
+  #
+  #   type: # TODO
+  #   def: # TODO
+
+  # - name: OSPS-BR-03
+  #   Any services involved in the project development and release
+  #   MUST be delivered using encrypted channels.
+  #
+  #   TBD
+  #
+  #   type: # TODO
+  #   def: # TODO
+
+  # - name: OSPS-DO-01
+  #   Project MUST have one or more mechanisms for public discussions about proposed changes
+  #
+  #   TBD
+  #
+  #   type: # TODO
+  #   def: # TODO
+
+  # - name: OSPS-DO-02
+  #   Project documentation MUST include an explanation of the contribution process.
+  #
+  #   [] Check SI for contribution-policy block
+  #   [] Check repo for CONTRIBUTING.md
+  #
+  #   type: # TODO
+  #   def: # TODO
+
+  # - name: OSPS-QA-01
+  #   Source code MUST be publicly readable and have a static URL
+  #
+  #   [] Check GitHub repository is public 
+  #
+  #   type: # TODO
+  #   def: # TODO
+
+  # - name: OSPS-QA-02
+  #   VCS MUST contain a public record of all changes (commits)
+  #
+  #   [] Check code lives in a git repository
+  #
+  #   type: # TODO
+  #   def: # TODO

--- a/resources/minder/osps-baseline-level1.yaml
+++ b/resources/minder/osps-baseline-level1.yaml
@@ -41,14 +41,14 @@ repository:
   #   type: # TODO
   #   def: # TODO
 
-  # - name: OSPS-AC-03
+  - name: OSPS-AC-03
   #   Branch protecton (push)
   #
-  #   [] Check GitHub's branch protection setting prevent direct pushes to main/master
+  #   [x] Check GitHub's branch protection setting to require pull requests 
   #
-  #   type: TODO
-  #   displayName: "[OSPS-AC-03] Prevent commits to main without a pull request"
-  #   def: # TODO
+    type: OSPS-AC-03
+    displayName: "[OSPS-AC-03] Prevent commits to main without a pull request"
+    def: {}
 
   - name: OSPS-AC-04
     #   Branch Prevent deletion of main branch

--- a/resources/minder/osps-baseline-level1.yaml
+++ b/resources/minder/osps-baseline-level1.yaml
@@ -47,8 +47,9 @@ repository:
   #   [x] Check GitHub's branch protection setting to require pull requests 
   #
     type: OSPS-AC-03
-    displayName: "[OSPS-AC-03] Prevent commits to main without a pull request"
-    def: {}
+    displayName: "(OSPS-AC-03) Prevent commits to main without a pull request"
+    def:
+      - required_pull_request_reviews: true
 
   - name: OSPS-AC-04
     #   Branch Prevent deletion of main branch
@@ -56,7 +57,7 @@ repository:
     #   [x] Check GitHub's branch protection config blocks deletin main branch
     #
     type: OSPS-AC-04
-    displayName: "[OSPS-AC-04] Prevent deletion of main branch"
+    displayName: "(OSPS-AC-04) Prevent deletion of main branch"
     def: {}
 
   # - name: OSPS-BR-01

--- a/resources/minder/osps-baseline-level1.yaml
+++ b/resources/minder/osps-baseline-level1.yaml
@@ -92,14 +92,14 @@ repository:
   #   type: # TODO
   #   def: # TODO
 
-  # - name: OSPS-DO-02
+  - name: OSPS-DO-02
   #   Project documentation MUST include an explanation of the contribution process.
   #
-  #   [] Check SI for contribution-policy block
+  #   [x] Check SI for contribution-policy block
   #   [] Check repo for CONTRIBUTING.md
   #
-  #   type: # TODO
-  #   def: # TODO
+    type: OSPS-DO-02
+    def: {}
 
   # - name: OSPS-QA-01
   #   Source code MUST be publicly readable and have a static URL

--- a/resources/minder/osps-baseline-level2.yaml
+++ b/resources/minder/osps-baseline-level2.yaml
@@ -153,15 +153,15 @@ repository:
   #   type: # TODO
   #   def: # TODO
 
-  # - name: OSPS-QA-06
-  #   VCS MUST NOT contain generated executable artifacts.
-  #
-  #   [] Check for binaries in repository
-  #   [] Check for binaries at PR time
-  #
-  #   type: TODO
-  #   displayName: "[OSPS-QA-06] No generated executable artifacts in the repo"
-  #   def: # TODO
+  - name: OSPS-QA-06
+    #   VCS MUST NOT contain generated executable artifacts.
+    #
+    #   [x] Check for binaries in repository
+    #   [] Check for binaries at PR time
+    #
+    type: OSPS-QA-06
+    displayName: "[OSPS-QA-06] No generated executable artifacts in the repo"
+    def: {}
 
   # - name: OSPS-LE-01
   #   VCS MUST require contributors to assert that they are legally authorized

--- a/resources/minder/osps-baseline-level2.yaml
+++ b/resources/minder/osps-baseline-level2.yaml
@@ -82,17 +82,15 @@ repository:
     type: OSPS-DO-03
     def: {}
 
-  # - name: OSPS-DO-04
+  - name: OSPS-DO-04
   #   Policy for coordinated vulnerability reporting, with a clear timeframe for response.
   #
-  #   [] Check SI for `vulnerability-reporting` block.`
+  #   [x] Check SI for `vulnerability-reporting` block.`
   #   [] Look for and check test of SECURITY.md for text patterns
   #
-  #   type: security_policy
-  #   displayName: "[OSPS-DO-04] Ensure there is a security policy file"
-  #   def:
-  #     filename: SECURITY.md
-
+    type: OSPS-DO-04
+    def: {}
+  
   # - name: OSPS-DO-05
   #   Project documentation MUST include a mechanism for reporting defects.
   #

--- a/resources/minder/osps-baseline-level2.yaml
+++ b/resources/minder/osps-baseline-level2.yaml
@@ -1,0 +1,174 @@
+# SPDX-FileCopyrightText: Copyright 2024 The OSPS Baseline Authors
+# SPDX-License-Identifier: Apache-2.0
+---
+# This file is part of a set of Minder security profiles to check a project's
+# compliance with the OSPS Baseline controls.
+#
+# This profiles, as the Baseline itself, are under active development
+# feel free to try them out but expect constant changes as the baseline
+# an support in Minder evolves.
+#
+# For more information about Minder to use this profie, check out the
+# project's documentation at https://github.com/mindersec/minder  
+
+
+version: v1
+type: profile
+name: osps_baseline_l2
+display_name: OSPS Baseline - Level 2
+context:
+  provider: github
+alert: "on"
+remediate: "off"
+
+
+# Checks that require data from the repo
+repository:
+  # - name: OSPS-AC-05
+  #   CI/CD pipelines MUST be configured to the lowest available privileges,
+  #   explicitly elevated.
+  #
+  #   [] Analize workflows to ensure permissions are pre-set to base
+  #
+  #   type: # TODO
+  #   def: # TODO
+
+  # - name: OSPS-BR-04
+  #   Released software assets MUST be created with automated pipelines.
+  #
+  #   [] Check SLSA attestation
+  #   [] Check workflows. Look for common release actions (eg softprops/action-gh-release)  
+  #
+  #   type: # TODO
+  #   def: # TODO
+
+  # - name: OSPS-BR-05
+  #   Pipelines MUST use standardized tooling where available
+  #
+  #   TBD
+  #
+  #   type: # TODO
+  #   def: # TODO
+
+  # - name: OSPS-BR-06
+  #   Releases MUST provide a descriptive log of functional and security modifications
+  #
+  #   [] Check SI for changelog entries
+  #   [] Check common file locations for changelog or release notes patterns
+  #   [] Check release assets for release notes
+  #   [] Check release for generated release notes
+  #
+  #   type: # TODO
+  #   def: # TODO
+
+  # - name: OSPS-BR-07
+  #   Released assets MUST be signed or accounted for in a signed manifest
+  #
+  #   [] Check and verify sigstore signatures
+  #   [] Check and verify GPG signatures
+  #   [] Check signed provenance attestation accounts for assets
+  #   [] Check for a signed SBOM accounting for artifacts
+  #   [] Check for a signed checksums.txt
+  #
+  #   type: # TODO
+  #   def: # TODO
+
+  # - name: OSPS-DO-03
+  #   Project documentation MUST provide user guides for all basic functionality.
+  #
+  #   [] Check for documentation in security insights
+  #   [] Check for common patterns (eg ./docs)
+  #
+  #   type: # TODO
+  #   def: # TODO
+
+  # - name: OSPS-DO-04
+  #   Policy for coordinated vulnerability reporting, with a clear timeframe for response.
+  #
+  #   [] Check SI for `vulnerability-reporting` block.`
+  #   [] Look for and check test of SECURITY.md for text patterns
+  #
+  #   type: security_policy
+  #   displayName: "[OSPS-DO-04] Ensure there is a security policy file"
+  #   def:
+  #     filename: SECURITY.md
+
+  # - name: OSPS-DO-05
+  #   Project documentation MUST include a mechanism for reporting defects.
+  #
+  #   [] Check for issues enabled in repository
+  #
+  #   type: # TODO
+  #   def: # TODO
+
+  # - name: OSPS-DO-06
+  #   Contribution guide
+  #
+  #   TBD   
+  #
+  #   type: # TODO
+  #   def: # TODO
+
+  # - name: OSPS-DO-07
+  #   Design documentation demonstrating all actions and actors within the system
+  #
+  #   TBD
+  #
+  #   type: # TODO
+  #   def: # TODO
+
+  # - name: OSPS-DO-11
+  #   Policy that code contributors are reviewed prior to granting escalated permissions 
+  #
+  #   TBD
+  #
+  #   type: # TODO
+  #   def: # TODO
+
+  # - name: OSPS-DO-12
+  #   Instructions to verify the integrity and authenticity of the release assets
+  #
+  #   [] Check for verification instructions in project docs 
+  #
+  #   type: # TODO
+  #   def: # TODO
+
+  # - name: OSPS-QA-03
+  #   Released assets MUST be delivered with a machine-readable list of all
+  #   direct and transitive internal software dependencies
+  #
+  #   [] Check for package manager lockfile
+  #   [] Check release assets for SBOM
+  #   [] Check SI for SBOM location
+  #
+  #   type: # TODO
+  #   def: # TODO
+
+  # - name: OSPS-QA-04
+  #   Status checks for commits MUST pass or require manual acknowledgement
+  #   prior to merge
+  #
+  #   [] Check repo settings requiring checks to pass
+  #
+  #   type: # TODO
+  #   def: # TODO
+
+  # - name: OSPS-QA-06
+  #   VCS MUST NOT contain generated executable artifacts.
+  #
+  #   [] Check for binaries in repository
+  #   [] Check for binaries at PR time
+  #
+  #   type: TODO
+  #   displayName: "[OSPS-QA-06] No generated executable artifacts in the repo"
+  #   def: # TODO
+
+  # - name: OSPS-LE-01
+  #   VCS MUST require contributors to assert that they are legally authorized
+  #   to commit the associated contributions 
+  #
+  #   [] Check GitHub app installations for DCO
+  #   [] Check GitHub app installations for CLA
+  #
+  #   type: # TODO
+  #   def: # TODO

--- a/resources/minder/osps-baseline-level2.yaml
+++ b/resources/minder/osps-baseline-level2.yaml
@@ -50,16 +50,16 @@ repository:
   #   type: # TODO
   #   def: # TODO
 
-  # - name: OSPS-BR-06
+  - name: OSPS-BR-06
   #   Releases MUST provide a descriptive log of functional and security modifications
   #
-  #   [] Check SI for changelog entries
+  #   [x] Check SI for changelog entries
   #   [] Check common file locations for changelog or release notes patterns
   #   [] Check release assets for release notes
   #   [] Check release for generated release notes
   #
-  #   type: # TODO
-  #   def: # TODO
+    type: # TODO
+    def: # TODO
 
   # - name: OSPS-BR-07
   #   Released assets MUST be signed or accounted for in a signed manifest

--- a/resources/minder/osps-baseline-level2.yaml
+++ b/resources/minder/osps-baseline-level2.yaml
@@ -73,14 +73,14 @@ repository:
   #   type: # TODO
   #   def: # TODO
 
-  # - name: OSPS-DO-03
+  - name: OSPS-DO-03
   #   Project documentation MUST provide user guides for all basic functionality.
   #
-  #   [] Check for documentation in security insights
+  #   [x] Check for documentation in security insights
   #   [] Check for common patterns (eg ./docs)
   #
-  #   type: # TODO
-  #   def: # TODO
+    type: OSPS-DO-03
+    def: {}
 
   # - name: OSPS-DO-04
   #   Policy for coordinated vulnerability reporting, with a clear timeframe for response.

--- a/resources/minder/osps-baseline-level3.yaml
+++ b/resources/minder/osps-baseline-level3.yaml
@@ -1,0 +1,76 @@
+# SPDX-FileCopyrightText: Copyright 2024 The OSPS Baseline Authors
+# SPDX-License-Identifier: Apache-2.0
+---
+# This file is part of a set of Minder security profiles to check a project's
+# compliance with the OSPS Baseline controls.
+#
+# This profiles, as the Baseline itself, are under active development
+# feel free to try them out but expect constant changes as the baseline
+# an support in Minder evolves.
+#
+# For more information about Minder to use this profie, check out the
+# project's documentation at https://github.com/mindersec/minder  
+
+
+version: v1
+type: profile
+name: osps_baseline_l3
+display_name: OSPS Baseline - Level 3
+context:
+  provider: github
+alert: "on"
+remediate: "off"
+
+
+# Checks that require data from the repo
+repository:
+  # - name: OSPS-DO-08
+  #   Policy that defines a threshold for remediation of SCA findings related
+  #   to vulnerabilities and licenses.
+  #
+  #   [] Try to find patterns in SECURITY.md
+  #
+  #   type: # TODO
+  #   def: # TODO
+
+  # - name: OSPS-DO-09
+  #   Descriptions of all external input and output interfaces of the released software assets
+  #
+  #   TBD
+  #
+  #   type: # TODO
+  #   def: # TODO
+
+  # - name: OSPS-DO-10
+  #   Policy to address SCA violations prior to any release.
+  #
+  #   [] Try to find patterns in SECURITY.md
+  #
+  #   type: # TODO
+  #   def: # TODO
+
+  # - name: OSPS-QA-05
+  #   Subproject repositories MUST enforce the same security requirements 
+  #
+  #   [] Look for and evaluate SLSA VSA from trusted Minder
+  #   [] Look for and evaluate VSA from other source
+  #
+  #   type: # TODO
+  #   def: # TODO
+
+  # - name: OSPS-QA-07
+  #   Changes to the code must be evaluated against known vulnerabilities and
+  #   blocked in the event of violations except when declared and supressed
+  #   as non exploitable.
+  #
+  #   [] Check for trivy/grype/snyk/etc. action at PR time
+  #   [] Use Minder's built-in OSV vulnreability scan
+  #   [] Read sarif results from step actions
+  #   [] Read vulnerability status attestation
+  #
+  #   [] Read VEX data from repository and supress
+  #   [] Read trivyignore config
+  #
+  #   type: TODO
+  #   displayName: "[OSPS-QA-07] Block vulnerabilities before release"
+  #   def: # TODO

--- a/resources/minder/rules/OSPS-AC-03.yaml
+++ b/resources/minder/rules/OSPS-AC-03.yaml
@@ -1,0 +1,84 @@
+# SPDX-FileCopyrightText: Copyright 2024 The OSPS Baseline Authors
+# SPDX-License-Identifier: Apache-2.0
+---
+# Derived from https://github.com/mindersec/minder-rules-and-profiles/blob/main/rule-types/github/branch_protection_require_pull_requests.yaml
+version: v1
+release_phase: beta
+type: rule-type
+name: OSPS-AC-03
+display_name: Only merge code from pull requests
+short_failure_message: Default branch does not require pull requests
+severity:
+  value: medium
+context:
+  provider: github
+description: Verifies that the default branch requires pull requests
+guidance: |
+  Ensure that the setting to require a pull request before merging to
+  a branch is enabled for the branch protection rule.
+
+  Enabling this requires that a pull request be opened before merging to a
+  branch.
+
+def:
+  in_entity: repository
+
+  # Defines the schema for parameters that will be passed to the rule
+  param_schema:
+    properties:
+      branch:
+        type: string
+        description: "The name of the branch to check. If left empty, the default branch will be used."
+        default: ""
+
+  # Defines the schema for writing a rule with this rule being checked
+  rule_schema:
+    properties:
+      required_pull_request_reviews:
+        type: boolean
+        description: |
+          When enabled, all commits must be made to a non-protected branch and
+          submitted via a pull request before they can be merged into a branch
+          that matches this rule.
+    required:
+      - required_pull_request_reviews
+
+  # Defines the configuration for ingesting data relevant for the rule
+  ingest:
+    type: rest
+    rest:
+      endpoint: '{{ $branch_param := index .Params "branch" }}/repos/{{.Entity.Owner}}/{{.Entity.Name}}/branches/{{if ne $branch_param "" }}{{ $branch_param }}{{ else }}{{ .Entity.DefaultBranch }}{{ end }}/protection'
+
+      # This is the method to use to retrieve the data. It should already default to JSON
+      parse: json
+      fallback:
+        - http_code: 404
+          body: |
+            {"http_status": 404, "message": "Not Protected"}
+
+  # Defines the configuration for evaluating data ingested against the given policy
+  eval:
+    type: rego
+    rego:
+      type: deny-by-default
+      def: |
+        package minder
+        
+        import future.keywords.every
+        import future.keywords.if
+        
+        default allow := false
+        default message := "Pull requests are not required"
+        
+        allow if {
+          input.ingested.required_pull_request_reviews.url != ""
+        }
+  # Defines the configuration for remediating the rule
+  remediate:
+    type: gh_branch_protection
+    gh_branch_protection:
+      # Note that this rule will ever only fail if there are no PR settings at all,
+      # so we can safely set the entire PR settings to an empty object. In that case,
+      # GH is actually helpful and selects reasonable defaults
+      patch: |
+        {"required_pull_request_reviews":{}}

--- a/resources/minder/rules/OSPS-AC-04.yaml
+++ b/resources/minder/rules/OSPS-AC-04.yaml
@@ -1,0 +1,65 @@
+# SPDX-FileCopyrightText: Copyright 2024 The OSPS Baseline Authors
+# SPDX-License-Identifier: Apache-2.0
+---
+# Derived from https://github.com/mindersec/minder-rules-and-profiles/blob/main/rule-types/github/branch_protection_allow_deletions.yaml
+version: v1
+release_phase: beta
+type: rule-type
+name: OSPS-AC-04
+display_name: Prevent main branch deletion
+short_failure_message: Default branch is not protected from being deleted
+severity:
+  value: medium
+context:
+  provider: github
+description: Prevents the default branch from being deleted
+guidance: |
+  This rule implements checks for OSPS-AC-04, ensuring that users
+  cannot delete the repository's main branch.
+def:
+  in_entity: repository
+
+  # Defines the schema for parameters that will be passed to the rule
+  param_schema:
+    properties:
+      branch:
+        type: string
+        description: "The name of the branch to check. If left empty, the default branch will be used."
+        default: ""
+
+  # Defines the schema for writing a rule with this rule being checked
+  rule_schema:
+    type: object
+    properties: {}
+
+  # Defines the configuration for ingesting data relevant for the rule
+  ingest:
+    type: rest
+    rest:
+      # This is the path to the data source. Given that this will evaluate
+      # for each repository tracked by the project, we use a template that
+      # will be evaluated for each repository. The structure to use is the
+      # protobuf structure for the entity that is being evaluated.
+      endpoint: '{{ $branch_param := index .Params "branch" }}/repos/{{.Entity.Owner}}/{{.Entity.Name}}/branches/{{if ne $branch_param "" }}{{ $branch_param }}{{ else }}{{ .Entity.DefaultBranch }}{{ end }}/protection'
+      
+      # This is the method to use to retrieve the data. It should already default to JSON
+      parse: json
+      fallback:
+        - http_code: 404
+          body: |
+            {"http_status": 404, "message": "Not Protected"}
+
+  # Defines the configuration for evaluating data ingested against the given policy
+  eval:
+    type: jq
+    jq:
+      - ingested:
+          def: ".allow_deletions.enabled"
+        constant: false
+
+  # Defines the configuration for remediating the rule
+  remediate:
+    type: gh_branch_protection
+    gh_branch_protection:
+      patch: |
+        {"allow_deletions": false }

--- a/resources/minder/rules/OSPS-BR-06.yaml
+++ b/resources/minder/rules/OSPS-BR-06.yaml
@@ -1,0 +1,42 @@
+# SPDX-FileCopyrightText: Copyright 2024 The OSPS Baseline Authors
+# SPDX-License-Identifier: Apache-2.0
+---
+# Requires the Security Insights data source to be installed:
+# https://github.com/mindersec/minder-rules-and-profiles/blob/main/data-sources/security-insights.yaml
+version: v1
+release_phase: alpha
+type: rule-type
+name: OSPS-BR-06
+display_name: Tests that a project has a log tracking functional changes
+short_failure_message: No changelog found
+severity:
+  value: low
+context:
+  provider: github
+description: |
+  Checks that the project publishes its changes in a release notes files or
+  changelog.
+guidance: |
+  This rule type looks for a changelog entry in a security insights file.
+def:
+  in_entity: repository
+  rule_schema:
+    type: object
+  ingest:
+    type: git
+  eval:
+    type: rego
+    data_sources:
+      - name: securityinsights
+    rego:
+      type: deny-by-default
+      def: |
+        package minder
+        import rego.v1
+
+        default allow := false
+
+        si = minder.datasource.securityinsights.parse({})
+        allow if {
+            count(si.header.changelog) > 0
+        }

--- a/resources/minder/rules/OSPS-DO-02.yaml
+++ b/resources/minder/rules/OSPS-DO-02.yaml
@@ -1,0 +1,44 @@
+# SPDX-FileCopyrightText: Copyright 2024 The OSPS Baseline Authors
+# SPDX-License-Identifier: Apache-2.0
+---
+# Requires the Security Insights data source to be installed:
+# https://github.com/mindersec/minder-rules-and-profiles/blob/main/data-sources/security-insights.yaml
+---
+version: v1
+release_phase: alpha
+type: rule-type
+name: OSPS-DO-02
+display_name: Tests that a project has a published contribution process
+short_failure_message: No contribution process found
+severity:
+  value: low
+context:
+  provider: github
+description: |
+  Checks that the project has a contribution process published
+guidance: |
+  This rule type checks for a contribution policy in the project. 
+  Currently, it will look for an contribution-policy/contributing-policy 
+  entry in the security insights file.
+def:
+  in_entity: repository
+  rule_schema:
+    type: object
+  ingest:
+    type: git
+  eval:
+    type: rego
+    data_sources:
+      - name: securityinsights
+    rego:
+      type: deny-by-default
+      def: |
+        package minder
+        import rego.v1
+
+        default allow := false
+
+        si = minder.datasource.securityinsights.parse({})
+        allow if {
+            count(si["contribution-policy"]["contributing-policy"]) > 0
+        }

--- a/resources/minder/rules/OSPS-DO-03.yaml
+++ b/resources/minder/rules/OSPS-DO-03.yaml
@@ -1,0 +1,42 @@
+# SPDX-FileCopyrightText: Copyright 2024 The OSPS Baseline Authors
+# SPDX-License-Identifier: Apache-2.0
+---
+# Requires the Security Insights data source to be installed:
+# https://github.com/mindersec/minder-rules-and-profiles/blob/main/data-sources/security-insights.yaml
+version: v1
+release_phase: alpha
+type: rule-type
+name: OSPS-DO-03
+display_name: Ensures a project has user documentation 
+short_failure_message: No project documentation process found
+severity:
+  value: low
+context:
+  provider: github
+description: |
+  Checks that the project has published documentation. 
+guidance: |
+  This rule type checks for the project's documentation. Currently, it looks for
+  sources in the Security Insights file.
+def:
+  in_entity: repository
+  rule_schema:
+    type: object
+  ingest:
+    type: git
+  eval:
+    type: rego
+    data_sources:
+      - name: securityinsights
+    rego:
+      type: deny-by-default
+      def: |
+        package minder
+        import rego.v1
+
+        default allow := false
+
+        si = minder.datasource.securityinsights.parse({})
+        allow if {
+            count(si["documentation"]) > 0
+        }

--- a/resources/minder/rules/OSPS-DO-04.yaml
+++ b/resources/minder/rules/OSPS-DO-04.yaml
@@ -1,0 +1,44 @@
+# SPDX-FileCopyrightText: Copyright 2024 The OSPS Baseline Authors
+# SPDX-License-Identifier: Apache-2.0
+---
+# Requires the Security Insights data source to be installed:
+# https://github.com/mindersec/minder-rules-and-profiles/blob/main/data-sources/security-insights.yaml
+---
+version: v1
+release_phase: alpha
+type: rule-type
+name: OSPS-DO-04
+display_name: Ensures a project has a vulnerability reporting policy 
+short_failure_message: No vulnerability reporting policy found.
+severity:
+  value: low
+context:
+  provider: github
+description: |
+  Checks that the project links a vulnerability reporting policy. 
+guidance: |
+  This rule type checks for the project's vulnerability reporting tool.
+  Currently, the rules looks for sources in the `vulnerability-reporting`
+  section of the Security Insights file.
+def:
+  in_entity: repository
+  rule_schema:
+    type: object
+  ingest:
+    type: git
+  eval:
+    type: rego
+    data_sources:
+      - name: securityinsights
+    rego:
+      type: deny-by-default
+      def: |
+        package minder
+        import rego.v1
+
+        default allow := false
+
+        si = minder.datasource.securityinsights.parse({})
+        allow if {
+            count(si["vulnerability-reporting"]) > 0
+        }

--- a/resources/minder/rules/OSPS-LE-02.yaml
+++ b/resources/minder/rules/OSPS-LE-02.yaml
@@ -1,0 +1,46 @@
+version: v1
+release_phase: alpha
+type: rule-type
+name: OSPS-LE-02
+display_name: The project's license is an OSI or FSF approved license
+short_failure_message: License not found or is not an OSI or FSF approved license.
+severity:
+  value: info
+context:
+  provider: github
+description: |
+  Ensure that the project's source code is distributed under a recognized and legally enforceable open source software license.
+guidance: |
+  Ensure that the project's source code is distributed under a recognized and legally enforceable open source software license, providing clarity on how the code can be used and shared by others.
+def:
+  in_entity: repository
+  rule_schema: {}
+  ingest:
+    type: git
+  eval:
+    type: rego
+    data_sources:
+      - name: ghapi
+      - name: "spdx-license-list"
+    rego:
+      type: constraints
+      def: |
+        package minder
+
+        import future.keywords.every
+        import future.keywords.if
+
+        violations[{"msg": msg}] {
+          resp := minder.datasource.ghapi.license({"owner": "mindersec", "repo": "minder"})
+          license := resp.body.license.spdx_id
+
+          resp2 := minder.datasource["spdx-license-list"].licenses({})
+          licenses := resp2.body.licenses
+          osi := { license.licenseId | license := licenses[_]; license.isOsiApproved }
+          fsf := { license.licenseId | license := licenses[_]; license.isFsfLibre }
+          approved_licenses := osi | fsf
+
+          not license in approved_licenses          
+
+          msg := sprintf("License '%s' is not approved", [license])
+        }

--- a/resources/minder/rules/OSPS-LE-03.yaml
+++ b/resources/minder/rules/OSPS-LE-03.yaml
@@ -1,0 +1,55 @@
+version: v1
+release_phase: alpha
+type: rule-type
+name: OSPS-LE-03
+display_name: LICENSE or COPYING files are available available
+short_failure_message: No LICENSE or COPYING file found.
+severity:
+  value: info
+context:
+  provider: github
+description: |
+  Ensure that either LICENSE file, COPYING file, or LICENSE/ folder are available.
+guidance: |
+  Source code must be accompanied by a `LICENSE` or `COPYING` file, or a `LICENSE/` folder at the root of the project source tree.
+def:
+  in_entity: repository
+  rule_schema: {}
+  ingest:
+    type: git
+    git: {}
+  eval:
+    type: rego
+    rego:
+      type: deny-by-default
+      def: |
+        package minder
+
+        import future.keywords.every
+        import future.keywords.if
+
+        default allow := false
+
+        allow if {
+          files := file.ls_glob("./LICENSE*")
+
+          some name
+          content := file.read(files[name])
+          "" != content
+        }
+
+        allow if {
+          files := file.ls_glob("./COPYING*")
+
+          some name
+          content := file.read(files[name])
+          "" != content
+        }
+
+        allow if {
+          files := file.ls_glob("./LICENSE/*")
+
+          some name
+          content := file.read(files[name])
+          "" != content
+        }

--- a/resources/minder/rules/OSPS-QA-06.yaml
+++ b/resources/minder/rules/OSPS-QA-06.yaml
@@ -1,0 +1,46 @@
+# SPDX-FileCopyrightText: Copyright 2024 The OSPS Baseline Authors
+# SPDX-License-Identifier: Apache-2.0
+---
+# Derived from https://github.com/mindersec/minder-rules-and-profiles/blob/main/rule-types/github/no_binaries_in_repo.yaml
+version: v1
+release_phase: beta
+type: rule-type
+name: OSPS-QA-06
+display_name: Ensure no binary files are checked in a repository
+short_failure_message: Binary files found in the repository.
+severity:
+  value: medium
+context:
+  provider: github
+description: |
+  Verifies that no binary artifacts are commited to the repository.
+guidance: |
+  This rule scans all files at HEAD trying to find binaries stored
+  in your repository.
+def:
+  in_entity: repository
+  rule_schema: {}
+  ingest:
+    type: git
+    git:
+  eval:
+    type: rego
+    rego:
+      type: constraints
+      def: |
+        package minder
+
+        import future.keywords.in
+        import future.keywords.if
+
+        violations[{"msg": msg}] if {
+          # Walk all files in the repo
+          files_in_repo := file.walk(".")
+
+          some current_file in files_in_repo
+
+          http_type := file.http_type(current_file)
+          http_type == "application/octet-stream"
+
+          msg := sprintf("Binary artifact found: %s", [current_file])
+        }


### PR DESCRIPTION
This pull request adds the three skeletons for minder profiles for each level of the baseline, the are written to be applied incrementally as a project matures:

- `osps-baseline-level1.yaml` → Level 1
- `osps-baseline-level2.yaml` → Level 2
- `osps-baseline-level3.yaml` → Level 3

This PR is intended to add the initial template for the profiles, but it already includes a number of rule types that can check for the following controls:

```
OSPS-AC-03
OSPS-AC-04
OSPS-BR-06
OSPS-DO-02
OSPS-DO-03
OSPS-DO-04
OSPS-QA-04
OSPS-QA-06
```


Signed-off-by: Adolfo García Veytia (puerco) <puerco@stacklok.com>
