### PR TITLE
Present criteria as not-tables

### DIFF
--- a/cmd/template.md
+++ b/cmd/template.md
@@ -15,11 +15,32 @@ For more information on the project and to make contributions, visit the [GitHub
 
 ## Criteria Overview
 
-| ID  | Maturity Level | Category | Criteria |
-| --- | -------------- | -------- | -------- |
+* [Level 1](#level-1)
+* [Level 2](#level-2)
+* [Level 3](#level-3)
+
+### Level 1
 
 {{- range .Criteria }}
-| [{{ .ID }}]({{ .ID | asLink }}) | {{ .MaturityLevel }} | {{ .Category }} | {{ .CriteriaText | collapseNewlines | addLinks }} |
+{{if eq .MaturityLevel 1}}
+**[{{ .ID }}]({{ .ID | asLink }})**: {{ .CriteriaText | addLinks }}
+{{ end }}
+{{- end }}
+
+### Level 2
+
+{{- range .Criteria }}
+{{if eq .MaturityLevel 2}}
+**[{{ .ID }}]({{ .ID | asLink }})**: {{ .CriteriaText | addLinks }}
+{{ end }}
+{{- end }}
+
+### Level 3
+
+{{- range .Criteria }}
+{{if eq .MaturityLevel 3}}
+**[{{ .ID }}]({{ .ID | asLink }})**: {{ .CriteriaText | addLinks }}
+{{ end }}
 {{- end }}
 
 ## Criteria Details
@@ -28,9 +49,15 @@ For more information on the project and to make contributions, visit the [GitHub
 
 ### {{ .ID }}
 
-**Criteria:**
+**Criterion:**
 
 {{ .CriteriaText | addLinks }}
+**Maturity Level:**
+{{ .MaturityLevel }}
+
+**Category:**
+{{ .Category }}
+
 **Objective:**
 
 {{ .Objective | addLinks}}


### PR DESCRIPTION
This improves small-screen readability and removes/moves extraneous information for easier skimming.

Some choices I made:

* I went with just the ID and criterion because the level is in the heading and the category is in the ID. I added them to the detailed view for completeness sake.
* I could have iterated over the three levels instead of copy pasta, but
    1. The more code blocks we add, the more complicated the template gets
    2. I think we'll eventually want to add a brief description of each level before we start listing the criteria, so this is future-proofing against that a bit
* Edit to add the other thing I was going to put here: this approach requires no muddling with CSS, adding plugins, etc and still achieves the overarching goal

Preview available as https://funnelfiasco.github.io/security-baseline/

Fixes #99