### PR TITLE
Add a maintenance process

### DIFF
--- a/.github/workflows/test-build.yml
+++ b/.github/workflows/test-build.yml
@@ -17,7 +17,7 @@ jobs:
         with:
             persist-credentials: false
       - name: Build content from yaml
-        run:  cd cmd && go run . compile --output ../docs/index.md
+        run:  cd cmd && go run . compile --output ../docs/versions/devel.md
       - name: Build with Jekyll
         uses: actions/jekyll-build-pages@44a6e6beabd48582f863aeeb6cb2151cc1716697 # v1.0.13
         with:

--- a/.github/workflows/web-publish.yml
+++ b/.github/workflows/web-publish.yml
@@ -31,7 +31,7 @@ jobs:
       - name: Setup Pages
         uses: actions/configure-pages@983d7736d9b0ae728b81ab479565c72886d7745b # v5.0.0
       - name: Build content from yaml
-        run:  cd cmd && go run . compile --output ../docs/index.md
+        run:  cd cmd && go run . compile --output ../docs/versions/devel.md
       - name: Build with Jekyll
         uses: actions/jekyll-build-pages@44a6e6beabd48582f863aeeb6cb2151cc1716697 # v1.0.13
         with:

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+docs/versions/devel.md

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,0 +1,17 @@
+# Open Source Security Baseline
+
+The Open Source Project Security Baseline (OSPS Baseline) is designed to act as a minimum definition of requirements for a project relative to it's maturity level.
+It is maintained by the [OpenSSF Security Baseline SIG](https://github.com/ossf/security-baseline/blob/main/governance/MAINTAINERS.md) according to the [project governance documentation](https://github.com/ossf/security-baseline/blob/main/governance/GOVERNANCE.md).
+
+## Versions
+
+Previous versions are presented for historical reference.
+Downstream consumers of the OSPS Baseline should specify their compliance against a specific version.
+Only the version labeled as "current" should be used for new compliance efforts.
+
+* [In-development version](docs/development)
+* Current version: [v1.0]() released YYYY-MM-DD
+* Previous versions:
+    * [v0.1] released YYYY-MM-DD
+
+Versions are managed according to the [Baseline maintenance process](maintenance).

--- a/docs/index.md
+++ b/docs/index.md
@@ -10,8 +10,10 @@ Downstream consumers of the OSPS Baseline should specify their compliance agains
 Only the version labeled as "current" should be used for new compliance efforts.
 
 * [In-development version](docs/development)
-* Current version: [v1.0]() released YYYY-MM-DD
+<!-- Leave this section out until there are historical and current versions to list.
+* Current version: [2025-04-01]()
 * Previous versions:
-    * [v0.1] released YYYY-MM-DD
+    * (none)
+-->
 
 Versions are managed according to the [Baseline maintenance process](maintenance).

--- a/docs/maintenance.md
+++ b/docs/maintenance.md
@@ -18,6 +18,5 @@ Previous versions of the Baseline will remain available, but are stable and not 
 Retired identifiers will remain in the source yaml files, clearly marked.
 * Substantial changes to the meaning of a criterion will be treated as a new criterion, resulting in a new identifier.
 Minor changes, including a change in level, between Baseline versions will not result in a new identifier.
-* The numeric portion of identifiers are assigned sequentially per category and level.
-Within a category and level, identifiers do not carry additional meaning.
-Moving a criterion between levels will (intentionally) result in assigning a new number.
+* The numeric portion of identifiers are assigned sequentially per category.
+Within a category, identifiers do not carry additional meaning.

--- a/docs/maintenance.md
+++ b/docs/maintenance.md
@@ -1,0 +1,22 @@
+# OSPS Baseline Maintenance Process
+
+* Normal text fixes to the criteria will be accepted via pull request and reviewed by the baseline project maintainers.
+Allowed changes are corrections to spelling/typos, grammar corrections, or enhancements to the supplementary text supporting the criteria, including: Objective, Implementation, Control Mappings, and Scorecard/Insights values.
+At least two project maintainers must review and approve these changes.
+* Substantive changes to Criteria, including changes to text that alters the originally stated meaning, new Criteria proposals, or removal of Criteria will be documented in GitHub PR(s) and reviewed regularly by the Baseline project maintainers for inclusion in the next release.
+These changes may reflect changes to global cybersecurity regulations and frameworks or changes in norms around application/project security practices.
+Any such substantive changes must be approved by a majority of the project's maintainers.
+* As appropriate, but at least annually, the Baseline project maintainers will evaluate the set of criteria and, if necessary, publish a new version of the Baseline.
+Previous versions of the Baseline will remain available, but are stable and not subject to change, except for minor changes to fix technical or typographic errors.
+* Any changes to the Baseline will be reflected within the Compliance Matrix, with new requirements flagged where the Baseline Criteria are appropriate.
+* Versions will follow a calendar-based identification system, using the `YYYY-MM-DD` format.
+* Downstream stakeholders will be notified via the project's mailing list on the changes and updates.
+
+## Identifiers
+
+* Identifiers for retired criteria MUST NOT be reused.
+Retired identifiers will remain in the source yaml files, clearly marked.
+* Substantial changes to the meaning of a criterion will be treated as a new criterion, resulting in a new identifier.
+Minor changes, including a change in level, between Baseline versions will not result in a new identifier.
+* The numeric portion of identifiers are assigned sequentially per category.
+They do not carry additional meaning.

--- a/docs/maintenance.md
+++ b/docs/maintenance.md
@@ -3,7 +3,7 @@
 * Normal text fixes to the criteria will be accepted via pull request and reviewed by the baseline project maintainers.
 Allowed changes are corrections to spelling/typos, grammar corrections, or enhancements to the supplementary text supporting the criteria, including: Objective, Implementation, and Control Mappings.
 At least two project maintainers must review and approve these changes.
-* Substantive changes to Criteria, including changes to text that alters the originally stated meaning, new Criteria proposals, or removal of Criteria will be documented in GitHub PR(s) and reviewed regularly by the Baseline project maintainers for inclusion in the next release.
+* Substantive changes to criteria, including changes to text that alters the originally stated meaning, new criteria proposals, or removal of criteria will be documented in GitHub PR(s) and reviewed regularly by the Baseline project maintainers for inclusion in the next release.
 These changes may reflect changes to global cybersecurity regulations and frameworks or changes in norms around application/project security practices.
 Any such substantive changes must be approved by a majority of the project's maintainers.
 * As appropriate, but at least annually, the Baseline project maintainers will evaluate the set of criteria and, if necessary, publish a new version of the Baseline.
@@ -18,5 +18,6 @@ Previous versions of the Baseline will remain available, but are stable and not 
 Retired identifiers will remain in the source yaml files, clearly marked.
 * Substantial changes to the meaning of a criterion will be treated as a new criterion, resulting in a new identifier.
 Minor changes, including a change in level, between Baseline versions will not result in a new identifier.
-* The numeric portion of identifiers are assigned sequentially per category.
-They do not carry additional meaning.
+* The numeric portion of identifiers are assigned sequentially per category and level.
+Within a category and level, identifiers do not carry additional meaning.
+Moving a criterion between levels will (intentionally) result in assigning a new number.

--- a/docs/maintenance.md
+++ b/docs/maintenance.md
@@ -1,7 +1,7 @@
 # OSPS Baseline Maintenance Process
 
 * Normal text fixes to the criteria will be accepted via pull request and reviewed by the baseline project maintainers.
-Allowed changes are corrections to spelling/typos, grammar corrections, or enhancements to the supplementary text supporting the criteria, including: Objective, Implementation, Control Mappings, and Scorecard/Insights values.
+Allowed changes are corrections to spelling/typos, grammar corrections, or enhancements to the supplementary text supporting the criteria, including: Objective, Implementation, and Control Mappings.
 At least two project maintainers must review and approve these changes.
 * Substantive changes to Criteria, including changes to text that alters the originally stated meaning, new Criteria proposals, or removal of Criteria will be documented in GitHub PR(s) and reviewed regularly by the Baseline project maintainers for inclusion in the next release.
 These changes may reflect changes to global cybersecurity regulations and frameworks or changes in norms around application/project security practices.


### PR DESCRIPTION
This will undoubtedly require a lot of discussion before it's mergeable, but here's a first pass at addressing #86 and #96, which are related issues.

The gist of my initial draft is that instead of publishing the list of criteria directly to baseline.openssf.org, we publish it to a development version page. The index page has information about the project and links to versions. When we cut a new version, we copy the `development.md` to 'v1.2.md` or whatever we call that version.

I took the discussion in #86 as a starting point for the `maintenance.md` page, with one notable change: I described a process that's more continuous, with versions happening at least once a year (but more often if necessary), instead of keeping criteria sitting as open PRs for long periods.

We'll probably want to move some of the contents of `README.md` into the `index.md` file (specifically the description of the criteria) and include a link in README to the website instead, but that can be done later. We probably also want to add a "this is a work-in-progress. don't use it for evaluating your project" to the in-development output, and a version/date tag to the "published" versions.