### PR TITLE
Added new category for threat modeling

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ Each entry has the following values:
   - DO: Documentation
   - LE: Legal
   - QA: Quality
-  - TM: Threat Modeling
+  - SA: Security Assessment
 - **Criterion**:
   - A concise statement of the requirement
   - Contains `MUST` or `MUST NOT` and is written in present tense

--- a/README.md
+++ b/README.md
@@ -17,11 +17,12 @@ Each entry has the following values:
   - Level 2: for any code project that has at least 2 maintainers and a small number of consistent users
   - Level 3: for any code project that has a large number of consistent users
 - **Category**:
-  - Access Control
-  - Build & Release
-  - Documentation
-  - Quality
-  - Legal
+  - AC: Access Control
+  - BR: Build & Release
+  - DO: Documentation
+  - LE: Legal
+  - QA: Quality
+  - TM: Threat Modeling
 - **Criterion**:
   - A concise statement of the requirement
   - Contains `MUST` or `MUST NOT` and is written in present tense

--- a/baseline.yaml
+++ b/baseline.yaml
@@ -507,7 +507,7 @@ criteria:
     control_mappings: # TODO
     security_insights_value: # TODO
 
-  - id: OSPS-TM-07
+  - id: OSPS-TM-02
     maturity_level: 2
     category: Threat Modeling
     criterion: |
@@ -552,7 +552,7 @@ criteria:
     control_mappings: # TODO
     security_insights_value: # TODO
 
-  - id: OSPS-TM-09
+  - id: OSPS-TM-03
     maturity_level: 3
     category: Threat Modeling
     criterion: |
@@ -961,6 +961,32 @@ criteria:
     control_mappings: # TODO
     security_insights_value: # TODO
     scorecard_probe: # sastToolRunsOnAllCommits 
+
+  - id: OSPS-TM-04
+    maturity_level: 2
+    category: Threat Modeling
+    criterion: |
+      The project documentation MUST include a
+      document that details the assets, threats,
+      and mitigations for the project.
+    rationale: |
+      Provide a structured approach to identifying
+      and addressing security threats to the
+      project, enabling contributors and users to
+      understand the risks and mitigations in place.
+    details: |
+      Create a threat model or assessment for the 
+      project. This will identify the assets,
+      threats, and mitigations for the project.
+      Include information on the potential threats
+      to the project's assets and the measures in
+      place to mitigate those threats.
+
+      The authoring process will be simplified if
+      including or referencing the output from
+      OSPS-TM-01, OSPS-TM-02, and OSPS-TM-03.
+    control_mappings: # TODO
+    security_insights_value: # TODO
 
 # # # #
 #

--- a/baseline.yaml
+++ b/baseline.yaml
@@ -404,16 +404,17 @@ criteria:
     scorecard_probe:
       - # None, may not be suitable
 
-  - id: OSPS-DO-03
+  - id: OSPS-TM-01
     maturity_level: 2
-    category: Documentation
+    category: Threat Modeling
     criterion: |
       The project documentation MUST provide user
       guides for all basic functionality.
     rationale: |
-      Ensure that users have a clear and
-      comprehensive understanding of the project's
-      current features in order to prevent damage
+      Ensure that users and threat assessors have a
+      clear and comprehensive understanding of the 
+      project's current features in order to
+      streamline assessments and prevent damage
       from misuse or misconfiguration.
     details: |
       Create user guides or documentation for all
@@ -423,7 +424,8 @@ criteria:
       known dangerous or destructive actions
       available, include highly-visible warnings.
     control_mappings: # TODO
-    security_insights_value: # TODO
+    security_insights_value: |
+      project.documentation.detailed-guide
 
   - id: OSPS-DO-04
     maturity_level: 2
@@ -505,9 +507,9 @@ criteria:
     control_mappings: # TODO
     security_insights_value: # TODO
 
-  - id: OSPS-DO-07
+  - id: OSPS-TM-07
     maturity_level: 2
-    category: Documentation
+    category: Threat Modeling
     criterion: |
       The project documentation MUST provide
       design documentation demonstrating all
@@ -550,19 +552,19 @@ criteria:
     control_mappings: # TODO
     security_insights_value: # TODO
 
-  - id: OSPS-DO-09
+  - id: OSPS-TM-09
     maturity_level: 3
-    category: Documentation
+    category: Threat Modeling
     criterion: |
       The project documentation MUST include
       descriptions of all external input and output
       interfaces of the released software assets.
     rationale: |
-      Provide users and developers with an
-      understanding of how to interact with the
-      project's software and integrate it with
-      other systems, enabling them to use the
-      software effectively.
+      Provide users, contributors, and assessors
+      with an understanding of how to interact with
+      the project's software to integrate it with
+      other systems, enabling them to fully
+      understand the software's capabilities.
     details: |
       Document all input and output interfaces of
       the released software assets, explaining how

--- a/baseline.yaml
+++ b/baseline.yaml
@@ -406,7 +406,7 @@ criteria:
 
   - id: OSPS-SA-01
     maturity_level: 2
-    category: Threat Modeling
+    category: Security Assessment
     criterion: |
       The project documentation MUST provide user
       guides for all basic functionality.
@@ -509,7 +509,7 @@ criteria:
 
   - id: OSPS-SA-02
     maturity_level: 2
-    category: Threat Modeling
+    category: Security Assessment
     criterion: |
       The project documentation MUST provide
       design documentation demonstrating all
@@ -554,7 +554,7 @@ criteria:
 
   - id: OSPS-SA-03
     maturity_level: 3
-    category: Threat Modeling
+    category: Security Assessment
     criterion: |
       The project documentation MUST include
       descriptions of all external input and output
@@ -964,7 +964,7 @@ criteria:
 
   - id: OSPS-TM-04
     maturity_level: 2
-    category: Threat Modeling
+    category: Security Assessment
     criterion: |
       The project documentation MUST include a
       document that details the assets, threats,

--- a/baseline.yaml
+++ b/baseline.yaml
@@ -404,7 +404,7 @@ criteria:
     scorecard_probe:
       - # None, may not be suitable
 
-  - id: OSPS-TM-01
+  - id: OSPS-SA-01
     maturity_level: 2
     category: Threat Modeling
     criterion: |
@@ -507,7 +507,7 @@ criteria:
     control_mappings: # TODO
     security_insights_value: # TODO
 
-  - id: OSPS-TM-02
+  - id: OSPS-SA-02
     maturity_level: 2
     category: Threat Modeling
     criterion: |
@@ -552,7 +552,7 @@ criteria:
     control_mappings: # TODO
     security_insights_value: # TODO
 
-  - id: OSPS-TM-03
+  - id: OSPS-SA-03
     maturity_level: 3
     category: Threat Modeling
     criterion: |

--- a/baseline.yaml
+++ b/baseline.yaml
@@ -962,7 +962,7 @@ criteria:
     security_insights_value: # TODO
     scorecard_probe: # sastToolRunsOnAllCommits 
 
-  - id: OSPS-TM-04
+  - id: OSPS-SA-04
     maturity_level: 2
     category: Security Assessment
     criterion: |


### PR DESCRIPTION
Adding category "Security Assessments" to match the phrasing in Security Insights v2.

This will need to be reorganized in the yaml (lots of that still to do)

This will allow us to extend the category to cover all topics necessary to incrementally produce a complete threat model based on what is reasonable for each maturity level.

Inspired by, but in lieu of, #121