### PR TITLE
Clarify OSPS-BR-01 further

### DIFF
--- a/baseline/OSPS-BR.yaml
+++ b/baseline/OSPS-BR.yaml
@@ -12,17 +12,17 @@ criteria:
     maturity_level: 1
     criterion: |
       The project's build and release pipelines
-      MUST NOT permit arbitrary input that allows
+      MUST NOT permit untrusted input that allows
       access to privileged resources.
     rationale: |
       Reduce the risk of code injection or other
       security vulnerabilities in the project's
       build and release by preventing untrusted input
-      to access privileged resources (code execution,
-      secret exfiltration, etc.)
+      to access privileged resources
+      (secret exfiltration, final release, etc.)
     details: |
       Ensure that any build and release pipeline actions
-      that accept externally-controlled input (e.g. git
+      that accept externally-controlled untrusted input (e.g. git
       branch names) do not use input in ways that could
       provide unintended access to privileged resources.
     control_mappings:

--- a/baseline/OSPS-BR.yaml
+++ b/baseline/OSPS-BR.yaml
@@ -21,7 +21,7 @@ criteria:
       to access privileged resources
       (secret exfiltration, final release, etc.)
     details: |
-      Ensure that any build and release pipeline actions
+      Ensure that any integration or release pipeline actions
       that accept externally-controlled untrusted input (e.g. git
       branch names) do not use input in ways that could
       provide unintended access to privileged resources.


### PR DESCRIPTION
This attempts to clarify OSPS-BR-01 further.

In particular, the term "arbitrary" currently used in the criterion doesn't really mean anything. Any sequence of bits could be "arbitrary". It doesn't matter if the bits are arbitrary or not.

What matters is that the undesired inputs are *untrusted*. In fact, the *rationale* uses the term "untrusted", but the criterion and details aren't consistent with the rationale. I think that was what was meant anyway :-).

Also: using "code execution" as a privileged resource is a terrible example. Any CI/CD pipeline does code execution, so expressly listing it here *confuses* things.
Let's instead list "secret exfiltration" and "final release" as privileged operations. Those are *much* clearer as examples of things you should be concerned about :-).

Not everyone has a separate "final release" step, and instead consider "merge to main" the same as final release. But even in that case, "merge to main" is a privileged operation that is not granted to everyone, so I think it still works.