### PR TITLE
Clarify that OSPS-AC-02 applies primarily to self-hosted solutions

### DIFF
--- a/baseline/OSPS-AC.yaml
+++ b/baseline/OSPS-AC.yaml
@@ -51,9 +51,8 @@ criteria:
       permissions granted to collaborators.
     details: |
       Most public version control systems are configured
-      in this manner.  If using a custom sytsem,
-      configure the project's version control
-      system to assign the lowest available
+      in this manner. Ensure the project's version control
+      system always assigns the lowest available
       permissions to collaborators by default when
       added, granting additional permissions only
       when necessary.

--- a/baseline/OSPS-AC.yaml
+++ b/baseline/OSPS-AC.yaml
@@ -40,7 +40,7 @@ criteria:
 
 
   - id: OSPS-AC-02
-    maturity_level: 3
+    maturity_level: 1
     criterion: |
       The project's version control system MUST
       restrict collaborator permissions to the
@@ -50,7 +50,9 @@ criteria:
       the project's repository by limiting the
       permissions granted to collaborators.
     details: |
-      Configure the project's version control
+      Most public version control systems are configured
+      in this manner.  If using a custom sytsem,
+      configure the project's version control
       system to assign the lowest available
       permissions to collaborators by default when
       added, granting additional permissions only

--- a/baseline/OSPS-AC.yaml
+++ b/baseline/OSPS-AC.yaml
@@ -40,7 +40,7 @@ criteria:
 
 
   - id: OSPS-AC-02
-    maturity_level: 1
+    maturity_level: 3
     criterion: |
       The project's version control system MUST
       restrict collaborator permissions to the


### PR DESCRIPTION
OSPS-AC-02 states:

> The project's version control system MUST restrict collaborator permissions to the lowest available privileges by default

Our maturity levels are defined as:

> * Level 1: for any code or non-code project with any number of maintainers or users
> * Level 2: for any code project that has at least 2 maintainers and a small number of consistent users
> * Level 3: for any code project that has a large number of consistent users

Given that Level 1 projects may be single-maintainer (at which the collaborator permissions are "admin everywhere"), it seems this should be at least level 2.  For code projects with a small number of maintainers and users (for example, 2 maintainers), I'd argue that "both maintainers are admins" is also fine.  For projects with a large number of maintainers (probably at least 5), restricting permissions seems more reasonable.
