### PR TITLE
Split BR-03 into development, release, and consumption requirements.

### DIFF
--- a/baseline/OSPS-BR.yaml
+++ b/baseline/OSPS-BR.yaml
@@ -62,20 +62,19 @@ criteria:
   - id: OSPS-BR-03
     maturity_level: 1
     criterion: |
-      Any websites, API responses or other
-      services involved in the project development
+      Any websites and version control systems
+      involved in the project development
       and release MUST be delivered using SSH,
       HTTPS or other encrypted channels.
     rationale: |
       Protect the confidentiality and integrity
-      of data transmitted between the project's
-      services and users, reducing the risk of
-      eavesdropping or data tampering.
+      of project source code during development,
+      reducing the risk of eavesdropping or data
+      tampering.
     details: |
-      Configure the project's websites, API
-      responses, and other services to use
-      encrypted channels such as SSH or HTTPS for
-      data transmission.
+      Configure the project's websites and version
+      control systems to use encrypted channels
+      such as SSH or HTTPS for data transmission.
     control_mappings: 
       BPB: B-B-11
       CRA: 1.2d, 1.2e, 1.2f, 1.2i, 1.2j, 1.2k
@@ -185,3 +184,50 @@ criteria:
     security_insights_value: 
       Signed-Releases
 
+  - id: OSPS-BR-09
+    maturity_level: 1
+    criterion: |
+      Any websites or other services involved in the
+      distribution of released software assets MUST
+      be delivered using HTTPS or other encrypted
+      channels.
+    rationale: |
+      Protect the confidentiality and integrity
+      of release assets consumed by the project's
+      users, reducing the risk of eavesdropping or
+      data tampering.
+    details: |
+      Configure the project's websites and
+      distribution services to use encrypted channels
+      such as HTTPS for data transmission.
+    control_mappings: 
+      BPB: B-B-11
+      CRA: 1.2d, 1.2e, 1.2f, 1.2i, 1.2j, 1.2k
+      SSDF: PO3.2, PS1
+      OCRE: 483-813, 124-564, 263-184
+    security_insights_value: # TODO
+
+  - id: OSPS-BR-10
+    maturity_level: 1
+    criterion: |
+      Any websites, API responses or other
+      services involved in release pipelines MUST be
+      fetched using SSH, HTTPS or other encrypted
+      channels.
+    rationale: |
+      Protect the confidentiality and integrity
+      of assets used in the release pipeline,
+      reducing the risk of eavesdropping or data
+      tampering.
+    details: |
+      Configure the project's release pipeline to
+      only fetch data from websites, API
+      responses, and other services which use
+      encrypted channels such as SSH or HTTPS for
+      data transmission.
+    control_mappings: 
+      BPB: B-B-11
+      CRA: 1.2d, 1.2e, 1.2f, 1.2i, 1.2j, 1.2k
+      SSDF: PO3.2, PS1
+      OCRE: 483-813, 124-564, 263-184
+    security_insights_value: # TODO

--- a/baseline/OSPS-BR.yaml
+++ b/baseline/OSPS-BR.yaml
@@ -65,7 +65,7 @@ criteria:
       Any websites and version control systems
       involved in the project development
       and release MUST be delivered using SSH,
-      HTTPS or other encrypted channels.
+      HTTPS, or other encrypted channels.
     rationale: |
       Protect the confidentiality and integrity
       of project source code during development,

--- a/baseline/OSPS-BR.yaml
+++ b/baseline/OSPS-BR.yaml
@@ -64,7 +64,7 @@ criteria:
     criterion: |
       Any websites and version control systems
       involved in the project development
-      and release MUST be delivered using SSH,
+      MUST be delivered using SSH,
       HTTPS, or other encrypted channels.
     rationale: |
       Protect the confidentiality and integrity


### PR DESCRIPTION
BR-03 requires:

> Any websites, API responses or other services involved in the project development and release MUST be delivered using SSH, HTTPS or other encrypted channels

Which, on the face of it, would require that all developers ensure that any email sent relating to the project and project decisions is delivered via SMTPS.  This is probably not intended.

I suspect this criteria will be more clear if we separate it into three concerns:

* Secure access to source code (and use of secure connections during code review) during development.

  This seems well-addressed by git forges such as GitHub, GitLab et al.

* Securing end-user access to released assets, including documentation.  This would align with the best practices badge on [sites_https](https://www.bestpractices.dev/en/criteria?details=true&rationale=true#0.sites_https) and [delivery_mitm](https://www.bestpractices.dev/en/criteria?details=true&rationale=true#0.delivery_mitm).

  This seems addressed by a combination of checking the homepage is HTTPS and using a standard release mechanism (e.g. GitHub releases, language package managers, OCI repositories)

* Securing external content during the release pipeline (e.g. a [SLSA attack D](https://slsa.dev/spec/v1.0/threats-overview) on an insecure download)

  This seems trickier to assess, though we could make a stab at checking Makefiles, shell scripts, and GitHub Actions for `http://` URLs.  This will obviously be leaky.
