### PR TITLE
Clarify that input and output interfaces means APIs.

### DIFF
--- a/baseline/OSPS-SA.yaml
+++ b/baseline/OSPS-SA.yaml
@@ -30,7 +30,7 @@ criteria:
     maturity_level: 1
     criterion: |
       The project documentation MUST include
-      descriptions of all external input and output
+      descriptions of all external software
       interfaces of the released software assets.
     rationale: |
       Provide users and developers with an
@@ -39,10 +39,16 @@ criteria:
       other systems, enabling them to use the
       software effectively.
     details: |
-      Document all input and output interfaces of
+      Document all software interfaces (APIs) of
       the released software assets, explaining how
       users can interact with the software and
       what data is expected or produced.
+    implementation: |
+      The project README should include a link to
+      the API documentation, often under a header
+      such as "Usage", "API Reference", or "Docs".
+      Documentation badges should also be considered
+      when recognized (e.g. readthedocs, godoc, etc.).
     control_mappings: # TODO
     security_insights_value: # TODO
 


### PR DESCRIPTION
Digging on the wording from best practices (which this seems to have been lifted from), suggests that the current wording is due to this issue:

https://github.com/coreinfrastructure/best-practices-badge/issues/450

"input and output interfaces" feels like it misses the point that this is focused on API documentation for connecting programs, which seems to have been the original intent.
