### PR TITLE
Add links to Minder rule types.

### DIFF
--- a/baseline/OSPS-AC.yaml
+++ b/baseline/OSPS-AC.yaml
@@ -95,6 +95,9 @@ criteria:
       CSF: PR.AA-02
       OCRE: 486-813, 124-564, 152-725
     security_insights_value: # TODO
+    minder_rules:
+      - name: osps-ac-03
+        url: https://github.com/mindersec/minder-rules-and-profiles/blob/main/security-baseline/rule-types/github/osps-ac-03.yaml
 
   - id: OSPS-AC-04
     maturity_level: 1
@@ -117,6 +120,9 @@ criteria:
       CSF: PR.AA-02
       OCRE: 486-813, 124-564,123-124, 152-725
     security_insights_value: # TODO
+    minder_rules:
+      - name: osps-ac-04
+        url: https://github.com/mindersec/minder-rules-and-profiles/blob/main/security-baseline/rule-types/github/osps-ac-04.yaml
 
   - id: OSPS-AC-05
     maturity_level: 2

--- a/baseline/OSPS-BR.yaml
+++ b/baseline/OSPS-BR.yaml
@@ -12,17 +12,19 @@ criteria:
     maturity_level: 1
     criterion: |
       The project's build and release pipelines
-      MUST NOT execute arbitrary code that is
-      input from outside of the build script.
+      MUST NOT permit arbitrary input that allows
+      access to privileged resources.
     rationale: |
       Reduce the risk of code injection or other
       security vulnerabilities in the project's
-      build and release processes by restricting
-      the execution of external code.
+      build and release by preventing untrusted input
+      to access privileged resources (code execution,
+      secret exfiltration, etc.)
     details: |
-      Ensure that the project's build and release
-      pipelines do not execute arbitrary code
-      provided from external sources.
+      Ensure that any build and release pipeline actions
+      that accept externally-controlled input (e.g. git
+      branch names) do not use input in ways that could
+      provide unintended access to privileged resources.
     control_mappings:
       CRA: 1.2f
       SSDF: PO3.2, PS1

--- a/baseline/OSPS-LE.yaml
+++ b/baseline/OSPS-LE.yaml
@@ -68,6 +68,9 @@ criteria:
       SSDF: PO3.2
       CSF: GV.OC-03
     security_insights_value: # TODO
+    minder_rules:
+      - name: osps-le-02
+        url: https://github.com/mindersec/minder-rules-and-profiles/blob/main/security-baseline/rule-types/github/osps-le-02.yaml
 
   - id: OSPS-LE-03
     maturity_level: 1
@@ -93,6 +96,9 @@ criteria:
       CRA: 1.2b
       SSDF: PO3.2
     security_insights_value: # TODO
+    minder_rules:
+      - name: osps-le-03
+        url: https://github.com/mindersec/minder-rules-and-profiles/blob/main/security-baseline/rule-types/github/osps-le-03.yaml
 
   - id: OSPS-LE-04
     maturity_level: 1

--- a/baseline/OSPS-QA.yaml
+++ b/baseline/OSPS-QA.yaml
@@ -27,7 +27,11 @@ criteria:
       documentation clarifies the primary source.
       Avoid frequent changes to the repository
       that would impact the repository URL.
-    control_mappings: # TODO
+    control_mappings: 
+      BPB: CC-B-1
+      CRA: 1.2b, 1.2j
+      SSDF: PS1, PS2, PS3, PW1.2
+      OCRE: 486-813, 124-564
     security_insights_value: # TODO
 
   - id: OSPS-QA-02
@@ -48,7 +52,13 @@ criteria:
       commit history. Avoid squashing or rewriting
       commits in a way that would obscure the
       author of any commits.
-    control_mappings: # TODO
+    control_mappings: 
+      BPB: CC-B-2, CC-B-3, R-B-5
+      CRA: 1.2b, 1.2f, 1.2j
+      SSDF: PO3.2, PS1, PS2, PS3, PW1.2, PW2.1,  
+      CSF: ID.AM-02, ID.RA-01, ID.RA-08
+      OC: 4.1.4
+      OCRE: 486-813, 124-564, 757-271
     security_insights_value: # TODO
 
   - id: OSPS-QA-03
@@ -77,7 +87,13 @@ criteria:
       This enables users to ingest this data in a
       standardized approach alongside other
       projects in their environment.
-    control_mappings: # TODO
+    control_mappings: 
+      BPB: Q-S-9
+      CRA: 1.2b, 2.1
+      SSDF: PO4, PS1
+      CSF: ID.AM-02
+      OC: 4.3.1
+      OCRE: 486-813, 124-564, 863-521
     security_insights_value: # TODO
 
   - id: OSPS-QA-04
@@ -104,7 +120,10 @@ criteria:
       status checks are NOT configured as a pass
       or fail requirement that approvers may be
       tempted to bypass.
-    control_mappings: # TODO
+    control_mappings: 
+      CRA: 1.2f, 1.2k
+      SSDF: PO4.1, PS1
+      CSF: ID.IM-02
     security_insights_value: # TODO
 
   - id: OSPS-QA-05
@@ -134,7 +153,10 @@ criteria:
       be held to a lower standard if they have
       lower levels of adoption or are not intended
       for general use.
-    control_mappings: # TODO
+    control_mappings: 
+      CRA: 1.2b, 1.2f
+      SSDF: PO3.2, PO4.1, PS1
+      OCRE: 486-813, 124-564
     security_insights_value: # TODO
 
   - id: OSPS-QA-06
@@ -158,7 +180,11 @@ criteria:
       should be instead be generated at build time
       or stored separately and fetched during a
       specific well-documented pipeline step.
-    control_mappings: # TODO
+    control_mappings: 
+      CRA: 1.2b
+      SSDF: PS1
+      OCRE: 486-813, 124-564
+    security_insights_value: # TODO
 
   - id: OSPS-QA-08
     maturity_level: 3
@@ -169,8 +195,14 @@ criteria:
       are run.
     rationale: # TODO
     details: # TODO
-    control_mappings: # TODO
+    control_mappings:       
+      BPB: Q-B-4
+      CRA: 2.3
+      SSDF: PW8.2
+      OC: 4.1.5
+      OCRE: 207-435, 088-377
     security_insights_value: # TODO
+
 
   - id: OSPS-QA-09
     maturity_level: 3
@@ -182,8 +214,15 @@ criteria:
       in an automated test suite.
     rationale: # TODO
     details: # TODO
-    control_mappings: # TODO
+    control_mappings:       
+      BPB: Q-B-8, Q-B-9, Q-B-10, Q-S-2
+      CRA: 2.3
+      SSDF: PW8.2
+      CSF: ID.IM-02
+      OC: 4.1.5
+      OCRE: 207-435, 088-377
     security_insights_value: # TODO
+
 
   - id: OSPS-QA-10
     maturity_level: 3
@@ -195,5 +234,6 @@ criteria:
       primary branch.
     rationale: # TODO
     implementation: # TODO
-    control_mappings: # TODO
+    control_mappings:       
+      BPB: B-G-3
     security_insights_value: # TODO

--- a/baseline/OSPS-QA.yaml
+++ b/baseline/OSPS-QA.yaml
@@ -33,6 +33,9 @@ criteria:
       SSDF: PS1, PS2, PS3, PW1.2
       OCRE: 486-813, 124-564
     security_insights_value: # TODO
+    minder_rules:
+      - name: osps-qa-01
+        url: https://github.com/mindersec/minder-rules-and-profiles/blob/main/security-baseline/rule-types/github/osps-qa-01.yaml
 
   - id: OSPS-QA-02
     maturity_level: 1

--- a/cmd/baseline.go
+++ b/cmd/baseline.go
@@ -22,6 +22,28 @@ type Criterion struct {
 	Details               string            `yaml:"details"`
 	ControlMappings       map[string]string `yaml:"control_mappings"`
 	SecurityInsightsValue string            `yaml:"security_insights_value"`
+	// MinderRules is a collection of references to Minder rules
+	// implementing the criterion.
+	MinderRules []MinderRule `yaml:"minder_rules"`
+}
+
+// MinderRules represents links to Minder rule type definitions along
+// with a configuration snippet.
+type MinderRule struct {
+	// Name is the name of the rule type or any other string to be
+	// shown as the link's anchor text.
+	Name string `yaml:"name"`
+	// URL is the destination of the link. It should preferably
+	// point to a rule type definition, but can also point to
+	// documentation.
+	URL string `yaml:"url"`
+	// Config is an example configuration snippet for the given
+	// rule. Rule configuration might span from simple strings to
+	// structured payloads, and depends on the rule type
+	// definition.
+	//
+	// This is currently rendered as YAML in the final template.
+	Config string `yaml:"config,omitempty"`
 }
 
 // Struct for holding the entire YAML structure

--- a/cmd/template.md
+++ b/cmd/template.md
@@ -83,14 +83,12 @@ For more information on the project and to make contributions, visit the [GitHub
 - [{{ .Name }}]({{ .URL }})
 {{- if .Config }}
 
-```yaml
-{{ .Config }}
-```
-
+   ```yaml
+   {{ .Config }}
+   ```
 {{- end }}
 {{- end }}
 {{- else }}
-_No minder rule identified._
 {{- end }}
 
 ---

--- a/cmd/template.md
+++ b/cmd/template.md
@@ -77,6 +77,22 @@ For more information on the project and to make contributions, visit the [GitHub
 **Security Insights Value:** {{ .SecurityInsightsValue }}
 {{- end }}
 
+**Minder Rule(s):**
+{{ if .MinderRules }}
+{{- range .MinderRules }}
+- [{{ .Name }}]({{ .URL }})
+{{- if .Config }}
+
+```yaml
+{{ .Config }}
+```
+
+{{- end }}
+{{- end }}
+{{- else }}
+_No minder rule identified._
+{{- end }}
+
 ---
 
 {{- end }}


### PR DESCRIPTION
This change adds links to existing Minder rule types that implement Baseline checks.

Note: OSPS-DO-01 and OSPS-DO-02 are no longer included under any of the levels of the security baselines.
Update: Seems like the two rules above have changed their governance criteria as part of https://github.com/ossf/security-baseline/pull/130/files
I will be addressing this separately and adding them in the next batch of rules that we link to Minder -- this will include moving and renaming the files and then updating the yamls again