### PR TITLE
Adjust documentation level requirements

### DIFF
--- a/baseline/OSPS-DO.yaml
+++ b/baseline/OSPS-DO.yaml
@@ -8,7 +8,7 @@ description: |
   understand the project's features and functionality.
 criteria:
   - id: OSPS-DO-03
-    maturity_level: 2
+    maturity_level: 1
     category: Documentation
     criterion: |
       The project documentation MUST provide user
@@ -35,7 +35,7 @@ criteria:
     security_insights_value: # TODO
 
   - id: OSPS-DO-05
-    maturity_level: 2
+    maturity_level: 1
     category: Documentation
     criterion: |
       The project documentation MUST include a
@@ -94,7 +94,7 @@ criteria:
     security_insights_value: # TODO
 
   - id: OSPS-DO-13
-    maturity_level: 1
+    maturity_level: 2
     category: Documentation
     criterion: |
       The project documentation MUST include a

--- a/baseline/OSPS-SA.yaml
+++ b/baseline/OSPS-SA.yaml
@@ -32,7 +32,7 @@ criteria:
     security_insights_value: # TODO
 
   - id: OSPS-SA-02
-    maturity_level: 1
+    maturity_level: 2
     criterion: |
       The project documentation MUST include
       descriptions of all external input and output


### PR DESCRIPTION
Per discussion in: https://openssf.slack.com/archives/C07DC6TT2QY/p1737570004362569

* Move DO-03 (basic user documentation) to level 1
* Move DO-05 (basic defect reporting) to level 1
* Move DO-13 (end-of-support documentation) to level 2.  There's no clear standard for recording this information at this point.
* Move SA-02 (document APIs) to level 2.  This seems like it should come after DO-03.
