### PR TITLE
Increase maturity level for BR-10

### DIFF
--- a/baseline/OSPS-BR.yaml
+++ b/baseline/OSPS-BR.yaml
@@ -208,7 +208,7 @@ criteria:
     security_insights_value: # TODO
 
   - id: OSPS-BR-10
-    maturity_level: 1
+    maturity_level: 2
     criterion: |
       Any websites, API responses or other
       services involved in release pipelines MUST be


### PR DESCRIPTION
While BR-03 (website and version control for development PRs) and BR-09 (asset download for end-users) are relatively easy to measure for usage of security channels (HTTPS and/or SSH), it's much harder to measure whether or not *every network call* invoked during a build process used a secure channel.

[Quoting from slack](https://openssf.slack.com/archives/C07DC6TT2QY/p1737737750305109?thread_ts=1737570004.362569&cid=C07DC6TT2QY):

> [Crob] is there a "tls = on"-like option in jenkins, etc.?  boy that sure would be nice

> [Evan] You'd need "tls = on" to flow into every other tool that Jenkins calls, too

> [Crob] #grumble... yeah
> [Crob] that reminds me, we have a security guide for configuring SCMs/VCSs.  maybe the BEST wg needs to craft on for CI/CD and publishing too

