### PR TITLE
Add data validator, validate subcommand

### DIFF
--- a/cmd/internal/cmd/root.go
+++ b/cmd/internal/cmd/root.go
@@ -13,7 +13,10 @@ func Execute() error {
 			cmd.Help() //nolint
 		},
 	}
+
+	// Add the subcommands
 	addCompile(rootCmd)
+	addValidate(rootCmd)
 
 	return rootCmd.Execute()
 }

--- a/cmd/internal/cmd/validate.go
+++ b/cmd/internal/cmd/validate.go
@@ -1,0 +1,83 @@
+// SPDX-FileCopyrightText: Copyright 2025 The OSPS Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package cmd
+
+import (
+	"errors"
+	"fmt"
+	"os"
+
+	"github.com/ossf/security-baseline/pkg/baseline"
+	"github.com/spf13/cobra"
+)
+
+type validateOptions struct {
+	baselinePath string
+}
+
+// Validate the options in context with arguments
+func (o *validateOptions) Validate() error {
+	errs := []error{}
+
+	if o.baselinePath == "" {
+		errs = append(errs, errors.New("baseline data path not specified"))
+	}
+	return errors.Join(errs...)
+}
+
+func (o *validateOptions) AddFlags(cmd *cobra.Command) {
+	cmd.PersistentFlags().StringVarP(
+		&o.baselinePath, "baseline", "b", "", "path to directory containing the baseline YAML definitions",
+	)
+
+}
+
+// addValidate adds the compile subcommand to the parent command
+func addValidate(parentCmd *cobra.Command) {
+	opts := validateOptions{}
+	validateCmd := &cobra.Command{
+		Use:           "validate",
+		Short:         "Validate the baseline data files",
+		SilenceUsage:  false,
+		SilenceErrors: true,
+		PreRunE: func(_ *cobra.Command, args []string) error {
+			if opts.baselinePath != "" && len(args) > 0 && opts.baselinePath != args[0] {
+				return fmt.Errorf("baseline data path specified twice")
+			}
+
+			if len(args) > 0 {
+				opts.baselinePath = args[0]
+			}
+			return nil
+		},
+		RunE: func(cmd *cobra.Command, args []string) error {
+			if err := opts.Validate(); err != nil {
+				return err
+			}
+
+			cmd.SilenceUsage = true
+
+			// Parse the data files
+			loader := baseline.NewLoader()
+			loader.DataPath = opts.baselinePath
+
+			bline, err := loader.Load()
+			if err != nil {
+				return err
+			}
+
+			// Generate the rendered version
+			validator := baseline.NewValidator()
+
+			if err = validator.Check(bline); err != nil {
+				fmt.Fprint(os.Stderr, "\n❌ Error validating the baseline data:\n")
+				return err
+			}
+			fmt.Fprint(os.Stderr, "\n✅ Baseline YAML data OK\n\n")
+			return nil
+		},
+	}
+	opts.AddFlags(validateCmd)
+	parentCmd.AddCommand(validateCmd)
+}

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -12,7 +12,7 @@ import (
 
 func main() {
 	if err := cmd.Execute(); err != nil {
-		fmt.Fprintf(os.Stderr, "ERROR: %v\n", err)
+		fmt.Fprintf(os.Stderr, "ERROR: %s\n", err.Error())
 		os.Exit(1)
 	}
 }

--- a/cmd/pkg/baseline/validator.go
+++ b/cmd/pkg/baseline/validator.go
@@ -4,48 +4,45 @@
 package baseline
 
 import (
+	"errors"
 	"fmt"
-	"log"
 	"slices"
 
 	"github.com/ossf/security-baseline/pkg/types"
 )
 
+func NewValidator() *Validator {
+	return &Validator{}
+}
+
 type Validator struct {
 }
 
 // Check verifies the data parsed for consistency and completeness
-func Check(b *types.Baseline) error {
+func (v *Validator) Check(b *types.Baseline) error {
 	var entryIDs []string
-	var failed bool
+	var errs = []error{}
 	for _, category := range b.Categories {
 		for _, entry := range category.Criteria {
 			if slices.Contains(entryIDs, entry.ID) {
-				failed = true
-				log.Printf("duplicate ID for 'criterion' for %s", entry.ID)
+				errs = append(errs, fmt.Errorf("duplicate ID for 'criterion' for %s", entry.ID))
 			}
 			if entry.ID == "" {
-				failed = true
-				log.Printf("missing ID for 'criterion' %s", entry.ID)
+				errs = append(errs, fmt.Errorf("missing ID for 'criterion' %s", entry.ID))
 			}
 			if entry.CriterionText == "" {
-				failed = true
-				log.Printf("missing 'criterion' text for %s", entry.ID)
+				errs = append(errs, fmt.Errorf("missing 'criterion' text for %s", entry.ID))
 			}
 			// For after all fields are populated:
 			// if entry.Rationale == "" {
-			// 	failed = true
-			// 	log.Printf("missing 'rationale' for %s", entry.ID)
+			//   errs = append(errs, fmt.Errorf("missing 'rationale' for %s", entry.ID))
 			// }
 			// if entry.Details == "" {
-			// 	failed = true
-			// 	log.Printf("missing 'details' for %s", entry.ID)
+			//   errs = append(errs, fmt.Errorf("missing 'details' for %s", entry.ID))
 			// }
 			entryIDs = append(entryIDs, entry.ID)
 		}
 	}
-	if failed {
-		return fmt.Errorf("error validating baseline")
-	}
-	return nil
+
+	return errors.Join(errs...)
 }


### PR DESCRIPTION
This PR builds on #187 and exposes the data validation logic in a new `baseline.Validator`. It also introduces a `validate` subcommand and a check to prevent rendering markdown when data does not validate (with a switch to turn it off).

Needs #187 and a rebase.


Signed-off-by: Adolfo García Veytia (Puerco) <adolfo.garcia@uservers.net>