### PR TITLE
Update absolute phrasing "considered secure"

### DIFF
--- a/docs/versions/devel.md
+++ b/docs/versions/devel.md
@@ -29,7 +29,7 @@ function toTop() {
 
 ## Overview
 
-The Open Source Project Security (OSPS) Baseline is a set of security criteria that projects should meet to be considered secure.
+The Open Source Project Security (OSPS) Baseline is a set of security criteria that projects should meet to demonstrate a strong security posture.
 The criteria are organized by maturity level and category.
 In the detailed subsections you will find the criterion, rationale, and details notes.
 


### PR DESCRIPTION
I've previously been advised using the phrase "secure" without qualification can be... problematic. ☺️ 