### PR TITLE
Fixed links broken by the period in IDs

### DIFF
--- a/cmd/pkg/baseline/template-functions.go
+++ b/cmd/pkg/baseline/template-functions.go
@@ -77,7 +77,9 @@ func addLinksTemplateFunction(lexicon []types.LexiconEntry, text string) string 
 }
 
 func asLinkTemplateFunction(text string) string {
-	return "#" + strings.ToLower(strings.ReplaceAll(text, " ", "-"))
+	return "#" + strings.ToLower(
+		strings.ReplaceAll(
+			strings.ReplaceAll(text, " ", "-"), ".", ""))
 }
 
 // loop through maturityLevels


### PR DESCRIPTION
[Preview](https://eddieknight.dev/security-baseline/versions/devel)

This PR fixes the ID links at the top of the document that fail to jump down to the corresponding section