### PR TITLE
Add dependabot config

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -1,0 +1,25 @@
+# SPDX-FileCopyrightText: Copyright 2025 The Open Source Project Security Baseline Authors
+# SPDX-License-Identifier: Apache-2.0
+---
+version: 2
+updates:
+  - package-ecosystem: gomod
+    directory: "cmd"
+    schedule:
+      interval: "daily"
+    open-pull-requests-limit: 10
+    groups:
+      gomod:
+        update-types:
+          - "patch"
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "daily"
+    open-pull-requests-limit: 10
+    groups:
+      actions:
+        update-types:
+          - "minor"
+          - "patch"


### PR DESCRIPTION
The tooling and github actions in the repo are growing enough to warrant turning on dependabot.

Signed-off-by: Adolfo García Veytia (Puerco) <adolfo.garcia@uservers.net>