### PR TITLE
OSCAL validation action

### DIFF
--- a/.github/workflows/oscal-check.yaml
+++ b/.github/workflows/oscal-check.yaml
@@ -18,7 +18,7 @@ jobs:
       - name: clone-baseline
         id: clone-baseline
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
-            with:
+        with:
                 persist-credentials: false
 
       - name: clone-go-oscal

--- a/.github/workflows/oscal-check.yaml
+++ b/.github/workflows/oscal-check.yaml
@@ -1,0 +1,41 @@
+# SPDX-FileCopyrightText: Copyright 2025 The Open Source Project Security Baseline Authors
+# SPDX-License-Identifier: Apache-2.0
+---
+name: Validate OSCAL Output
+
+on:
+  pull_request: {}
+  workflow_dispatch: {}
+
+permissions:
+  contents: read
+
+jobs:
+  verify:
+    runs-on: ubuntu-latest
+    steps:
+      - name: clone-baseline
+        id: clone-baseline
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+
+      - name: clone-go-oscal
+        id: clone-go-oscal
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+            repository: defenseunicorns/go-oscal
+            path: .build/go-oscal/
+
+      - uses: actions/setup-go@f111f3307d8850f501ac008e886eec1fd1932a34 # v5.3.0
+        name: setup-go
+        with:
+          go-version: '1.24'
+          check-latest: true
+          cache: true
+
+      - run: |
+          go build -C .build/go-oscal/ -o ${PWD}/go-oscal
+          go build -C cmd/  -o ../baseline-compiler
+          ./baseline-compiler oscal -b baseline > oscal-sample.json
+          ./go-oscal validate --input-file oscal-sample.json 
+            
+            

--- a/.github/workflows/oscal-check.yaml
+++ b/.github/workflows/oscal-check.yaml
@@ -18,6 +18,8 @@ jobs:
       - name: clone-baseline
         id: clone-baseline
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+            with:
+                persist-credentials: false
 
       - name: clone-go-oscal
         id: clone-go-oscal

--- a/.github/workflows/oscal-check.yaml
+++ b/.github/workflows/oscal-check.yaml
@@ -27,6 +27,7 @@ jobs:
         with:
             repository: defenseunicorns/go-oscal
             path: .build/go-oscal/
+            persist-credentials: false
 
       - uses: actions/setup-go@f111f3307d8850f501ac008e886eec1fd1932a34 # v5.3.0
         name: setup-go

--- a/.github/workflows/oscal-check.yaml
+++ b/.github/workflows/oscal-check.yaml
@@ -12,6 +12,7 @@ permissions:
 
 jobs:
   verify:
+    name: Setup and Generate
     runs-on: ubuntu-latest
     steps:
       - name: clone-baseline
@@ -32,10 +33,22 @@ jobs:
           check-latest: true
           cache: true
 
+      - name: Setup Java
+        uses: actions/setup-java@c3ac5dd0ed8db40fedb61c32fbe677e6b355e94c
+        id: setup-java
+        with:
+          distribution: adopt
+          java-version: 11
+
       - run: |
           go build -C .build/go-oscal/ -o ${PWD}/go-oscal
           go build -C cmd/  -o ../baseline-compiler
           ./baseline-compiler oscal -b baseline > oscal-sample.json
           ./go-oscal validate --input-file oscal-sample.json 
+
+      - name: Validate Catalog with oscal-club/NIST CLI
+        uses: oscal-club/oscal-cli-action@17a1414ce8a95a96959d5524984a0b4baf8f2158 # v1.0.4
+        with:
+          args: catalog validate oscal-sample.json 
             
             


### PR DESCRIPTION
This PR adds a github action to verify the OSCAL output of the baseline compiler whenever a PR is opened.

This PR introduces a new file but requires #194 to run, here is an example run:
https://github.com/puerco/security-baseline/actions/runs/13448472115/job/37578580471

Signed-off-by: Adolfo García Veytia (Puerco) <adolfo.garcia@uservers.net>