### PR TITLE
Move several requirements out of Lv2

### DIFF
--- a/baseline/OSPS-AC.yaml
+++ b/baseline/OSPS-AC.yaml
@@ -149,7 +149,7 @@ controls:
 
   - id: OSPS-AC-04
     title: |
-      Configure the project's permissions in CI/CD pipelines
+      Restrict the project's permissions in CI/CD pipelines based on context
     objective: |
       Reduce the risk of unauthorized access to the project's build and release
       processes by limiting the permissions granted to steps within the CI/CD
@@ -183,7 +183,6 @@ controls:
           The project's permissions in CI/CD pipelines MUST be configured to the
           lowest available privileges except when explicitly elevated.
         applicability:
-          - Maturity Level 2
           - Maturity Level 3
         recommendation: |
           Configure the project's CI/CD pipelines to assign the lowest available
@@ -191,34 +190,7 @@ controls:
           only when necessary for specific tasks. In some version control
           systems, this may be possible at the organizational or repository
           level. If not, set permissions at the top level of the pipeline.
-
-  - id: OSPS-AC-05
-    title: |
-      Limit the permissions granted to CI/CD pipelines by default
-    objective: |
-      Reduce the risk of unauthorized access to the project's build and release
-      processes by limiting the permissions granted to new CI/CD pipelines.
-    family: Access Control
-    mappings:
-      - reference-id: CRA
-        identifiers:
-          - 1.2f
-      - reference-id: SSDF
-        identifiers:
-          - PO3.2
-          - PS1
-      - reference-id: CSF
-        identifiers:
-          - PR.AA-02
-      - reference-id: OCRE
-        identifiers:
-          - 486-813
-          - 124-564
-          - 347-507
-          - 263-284
-          - 123-124
-    assessment-requirements:
-      - id: OSPS-AC-05.01
+      - id: OSPS-AC-04.02
         text: |
           The project's CI/CD pipelines MUST restrict permissions to the lowest
           available privileges by default.

--- a/baseline/OSPS-AC.yaml
+++ b/baseline/OSPS-AC.yaml
@@ -178,9 +178,20 @@ controls:
           - 263-284
           - 123-124
     assessment-requirements:
+      - id: OSPS-AC-04.02
+        text: |
+          The project's settings for CI/CD pipelines MUST restrict permissions
+          to the lowest available privileges by default.
+        applicability:
+          - Maturity Level 2
+          - Maturity Level 3
+        recommendation: |
+          Configure the project's settings to assign the lowest available
+          permissions to new pipelines by default, granting additional
+          permissions only when necessary for specific tasks.
       - id: OSPS-AC-04.01
         text: |
-          The project's permissions in CI/CD pipelines MUST be configured to the
+          The project's permission assignments in CI/CD pipelines MUST use the
           lowest available privileges except when explicitly elevated.
         applicability:
           - Maturity Level 3
@@ -190,14 +201,3 @@ controls:
           only when necessary for specific tasks. In some version control
           systems, this may be possible at the organizational or repository
           level. If not, set permissions at the top level of the pipeline.
-      - id: OSPS-AC-04.02
-        text: |
-          The project's CI/CD pipelines MUST restrict permissions to the lowest
-          available privileges by default.
-        applicability:
-          - Maturity Level 2
-          - Maturity Level 3
-        recommendation: |
-          Configure the project's CI/CD pipelines to assign the lowest available
-          permissions to new pipelines by default, granting additional permissions
-          only when necessary for specific tasks.

--- a/baseline/OSPS-AC.yaml
+++ b/baseline/OSPS-AC.yaml
@@ -178,7 +178,7 @@ controls:
           - 263-284
           - 123-124
     assessment-requirements:
-      - id: OSPS-AC-04.02
+      - id: OSPS-AC-04.01
         text: |
           The project's settings for CI/CD pipelines MUST restrict permissions
           to the lowest available privileges by default.
@@ -189,7 +189,7 @@ controls:
           Configure the project's settings to assign the lowest available
           permissions to new pipelines by default, granting additional
           permissions only when necessary for specific tasks.
-      - id: OSPS-AC-04.01
+      - id: OSPS-AC-04.02
         text: |
           The project's permission assignments in CI/CD pipelines MUST use the
           lowest available privileges except when explicitly elevated.

--- a/baseline/OSPS-BR.yaml
+++ b/baseline/OSPS-BR.yaml
@@ -294,6 +294,7 @@ controls:
           Any websites, API responses or other services involved in release
           pipelines MUST be fetched using encrypted channels.
         applicability:
+          - Maturity Level 1
           - Maturity Level 2
           - Maturity Level 3
         recommendation: |

--- a/baseline/OSPS-DO.yaml
+++ b/baseline/OSPS-DO.yaml
@@ -143,7 +143,6 @@ controls:
           expected identity of the person or process authoring the software
           release.
         applicability:
-          - Maturity Level 2
           - Maturity Level 3
         recommendation: |
           Instructions in the project should contain information about the
@@ -183,7 +182,6 @@ controls:
           The project documentation MUST include a descriptive statement about
           the scope and duration of support.
         applicability:
-          - Maturity Level 2
           - Maturity Level 3
         recommendation: |
           In order to communicate the scope and duration of support for the

--- a/baseline/OSPS-GV.yaml
+++ b/baseline/OSPS-GV.yaml
@@ -163,7 +163,6 @@ controls:
           are reviewed prior to granting escalated permissions to sensitive
           resources.
         applicability:
-          - Maturity Level 2
           - Maturity Level 3
         recommendation: |
           Publish an enforceable policy in the project documentation that

--- a/baseline/OSPS-QA.yaml
+++ b/baseline/OSPS-QA.yaml
@@ -214,7 +214,6 @@ controls:
           project. Others may be held to a lower standard if they have lower
           levels of adoption or are not intended for general use.
 
-
   - id: OSPS-QA-05
     title: |
       Remove generated executable artifacts from the version control system
@@ -298,7 +297,6 @@ controls:
           The project's documentation MUST clearly document when and how tests
           are run.
         applicability:
-          - Maturity Level 2
           - Maturity Level 3
         recommendation: |
           Add a section to the contributing documentation that explains how to


### PR DESCRIPTION
7 fewer checks in level 2 should help with the feedback we got about lv2 being overwhelming