### PR TITLE
Style the admonitions

### DIFF
--- a/.github/ISSUE_TEMPLATE/release.yaml
+++ b/.github/ISSUE_TEMPLATE/release.yaml
@@ -24,6 +24,8 @@ body:
         - label: |
             In the `docs/versions/<VERSION>.md` file, change the `Version: devel` to have the version number of the new version
         - label: |
+            In the `docs/versions/<VERSION>.md` file, remove the "not for production use" warning
+        - label: |
             Move the link to the "current" version in `docs/index.md` to the "previous versions" list
         - label: |
             Add the link to the new version to the "current version" in `docs/index.md` (e.g. `Current version: [2025-02-04](versions/2025-02-04]`) 

--- a/cmd/template.md
+++ b/cmd/template.md
@@ -1,6 +1,9 @@
 # Open Source Project Security Baseline
 
-Version: devel (not for production use)
+Version: devel
+
+{: .warning}
+Not for production use.
 
 <!-- A button for returning to the top of the page -->
 <button onclick="toTop()" id="topButton" title="Go to top"

--- a/docs/assets/css/style.scss
+++ b/docs/assets/css/style.scss
@@ -1,0 +1,18 @@
+---
+---
+
+@import "{{ site.theme }}";
+
+.warning {
+    background: rgba(114, 83, 237, 0.2);
+    border-left: 4px solid #381885;
+    border-radius: 4px;
+    box-shadow: 0 1px 2px rgba(0, 0, 0, 0.12), 0 3px 10px rgba(0, 0, 0, 0.08);
+    padding: .8rem;
+}
+
+.warning::before {
+    font-weight: bold;
+    font-size: 80%;
+    content: "WARNING ";
+}

--- a/docs/versions/2025-02-25-rc.md
+++ b/docs/versions/2025-02-25-rc.md
@@ -1,7 +1,7 @@
 # Open Source Project Security Baseline - v2025-02-25-rc
 
-> [!WARNING]
-> This is a release candidate, not intended for production use.
+{: .warning }
+This is a release candidate, not intended for production use.
 
 <button onclick="toTop()" id="topButton" title="Go to top"
 style="display: none; position: fixed; bottom: 20px; right: 30px; border: none; background-color: CornflowerBlue; color: white; cursor: pointer; padding: 10px; border-radius: 10px; font-size: 18px;">to top</button> 


### PR DESCRIPTION
Right now, I've only created a "warning" admonition, but we can make more if needed (though I don't think we will need it).

I've implemented this in the least-fancy way that I could get away with because I don't want to go adding more dependencies or hacking up the theme we're using. The result is this:

![Screenshot 2025-02-24 at 10 13 00 AM](https://github.com/user-attachments/assets/fd3bebbc-8419-4c7b-b09b-d3df38ba9349)

This PR:
* Adds the CSS necessary
* Adds a "not for production use" warning to the template
* Updates the RC for tomorrow to use the styling
* Adds a step to the release checklist to remove this for releases

Fixes #204 