### PR TITLE
Update a broken link to Best Practices Badge

### DIFF
--- a/baseline/frameworks.yaml
+++ b/baseline/frameworks.yaml
@@ -2,7 +2,7 @@ mapping-references:
   - id: BPB
     title: OpenSSF Best Practices Badge
     version: 2024
-    url: https://github.com/coreinfrastructure/best-practices-badge/blob/main/controls/controls.yml
+    url: https://github.com/coreinfrastructure/best-practices-badge/blob/main/criteria/criteria.yml
   - id: CSF
     title: NIST Cybersecurity Framework
     version: 2.0

--- a/docs/versions/2025-02-25.md
+++ b/docs/versions/2025-02-25.md
@@ -2161,7 +2161,7 @@ can be merged.
 
 Controls within this document may map to the following external frameworks:
 
-- [OpenSSF Best Practices Badge (BPB): 2024](https://github.com/coreinfrastructure/best-practices-badge/blob/main/controls/controls.yml)
+- [OpenSSF Best Practices Badge (BPB): 2024](https://github.com/coreinfrastructure/best-practices-badge/blob/main/criteria/criteria.yml)
 - [NIST Cybersecurity Framework (CSF): 2.0](https://nvlpubs.nist.gov/nistpubs/CSWP/NIST.CSWP.29.pdf)
 - [Cyber Resilience Act (CRA): 20.11.2024](https://eur-lex.europa.eu/legal-content/EN/TXT/HTML/?uri=OJ:L_202402847#tit_1)
 - [Software Security Development Framework (SSDF): 1.1](https://csrc.nist.gov/pubs/sp/800/218/final)


### PR DESCRIPTION
We got too enthusiastic with s/criteria/controls :-)

Includes a fix to the published version, which is allowed under our rules, but I wanted to highlight it.