### PR TITLE
normalize NIST SSDF references to XX.0.0 format

### DIFF
--- a/baseline/OSPS-AC.yaml
+++ b/baseline/OSPS-AC.yaml
@@ -28,9 +28,9 @@ controls:
           - 1.2f
       - reference-id: SSDF
         identifiers:
-          - PO3.2
-          - PS1
-          - PS2
+          - PO.3.2
+          - PS.1
+          - PS.2
       - reference-id: CSF
         identifiers:
           - PR.A-02
@@ -73,10 +73,10 @@ controls:
           - 1.2f
       - reference-id: SSDF
         identifiers:
-          - PO2
-          - PO3.2
-          - PS1
-          - PS2
+          - PO.2
+          - PO.3.2
+          - PS.1
+          - PS.2
       - reference-id: CSF
         identifiers:
           - PR.AA-02
@@ -118,9 +118,9 @@ controls:
           - 1.2f
       - reference-id: SSDF
         identifiers:
-          - PO3.2
-          - PS1
-          - PS2
+          - PO.3.2
+          - PS.1
+          - PS.2
       - reference-id: CSF
         identifiers:
           - PR.A-02
@@ -178,10 +178,10 @@ controls:
           - 1.2f
       - reference-id: SSDF
         identifiers:
-          - PO2
-          - PO3.2
-          - PS1
-          - PS2
+          - PO.2
+          - PO.3.2
+          - PS.1
+          - PS.2
       - reference-id: CSF
         identifiers:
           - PR.AA-02

--- a/baseline/OSPS-BR.yaml
+++ b/baseline/OSPS-BR.yaml
@@ -23,10 +23,10 @@ controls:
           - 1.2f
       - reference-id: SSDF
         identifiers:
-          - PO3.2
-          - PO5.2
-          - PS1
-          - PS2
+          - PO.3.2
+          - PO.5.2
+          - PS.1
+          - PS.2
       - reference-id: CSF
         identifiers:
           - PR.AA-02
@@ -79,10 +79,10 @@ controls:
           - 1.2f
       - reference-id: SSDF
         identifiers:
-          - PO3.2
-          - PS1
-          - PS2
-          - PS3
+          - PO.3.2
+          - PS.1
+          - PS.2
+          - PS.3
       - reference-id: OCRE
         identifiers:
           - 486-813
@@ -136,10 +136,10 @@ controls:
           - 1.2k
       - reference-id: SSDF
         identifiers:
-          - PO3.2
-          - PO5.2
-          - PS1
-          - PS2
+          - PO.3.2
+          - PO.5.2
+          - PS.1
+          - PS.2
       - reference-id: OCRE
         identifiers:
           - 483-813
@@ -202,10 +202,10 @@ controls:
           - 2.5
       - reference-id: SSDF
         identifiers:
-          - PS1
-          - PS2
-          - PS3
-          - PW1.2
+          - PS.1
+          - PS.2
+          - PS.3
+          - PW.1.2
       - reference-id: OCRE
         identifiers:
           - 483-813
@@ -264,9 +264,9 @@ controls:
           - 2.3
       - reference-id: SSDF
         identifiers:
-          - PO3.2
-          - PS1
-          - PS2
+          - PO.3.2
+          - PS.1
+          - PS.2
       - reference-id: OCRE
         identifiers:
           - 486-813
@@ -301,10 +301,10 @@ controls:
     mappings:
       - reference-id: SSDF
         identifiers:
-          - PO5.2
-          - PS2
-          - PS2.1
-          - PW6.2
+          - PO.5.2
+          - PS.2
+          - PS.2.1
+          - PW.6.2
       - reference-id: ScCrd
         identifiers:
           - Signed-Releases

--- a/baseline/OSPS-DO.yaml
+++ b/baseline/OSPS-DO.yaml
@@ -30,7 +30,7 @@ controls:
           - 1.2k
       - reference-id: SSDF
         identifiers:
-          - PW1.2
+          - PW.1.2
       - reference-id: CSF
         identifiers:
           - GV.OC-04
@@ -82,10 +82,10 @@ controls:
           - 2.6
       - reference-id: SSDF
         identifiers:
-          - PW1.2
-          - RV1.1
-          - RV2.1
-          - RV1.2
+          - PW.1.2
+          - RV.1.1
+          - RV.2.1
+          - RV.1.2
       - reference-id: CSF
         identifiers:
           - RS.MA-02
@@ -129,11 +129,11 @@ controls:
           - 1.2d
       - reference-id: SSDF
         identifiers:
-          - PO4.2
+          - PO.4.2
           - PS.2
-          - PS2.1
-          - PS3.1
-          - RV1.3
+          - PS.2.1
+          - PS.3.1
+          - RV.1.3
       - reference-id: OCRE
         identifiers:
           - 171-222
@@ -183,9 +183,9 @@ controls:
           - R-B-3
       - reference-id: SSDF
         identifiers:
-          - PO4.2
-          - PS3.1
-          - RV1.3
+          - PO.4.2
+          - PS.3.1
+          - RV.1.3
       - reference-id: OC
         identifiers:
           - 4.1

--- a/baseline/OSPS-GV.yaml
+++ b/baseline/OSPS-GV.yaml
@@ -72,8 +72,8 @@ controls:
           - 2.6
       - reference-id: SSDF
         identifiers:
-          - PS3
-          - PW1.2
+          - PS.3
+          - PW.1.2
     assessment-requirements:
       - id: OSPS-GV-02.01
         text: |
@@ -111,7 +111,7 @@ controls:
           - 2.4
       - reference-id: SSDF
         identifiers:
-          - PW1.2
+          - PW.1.2
       - reference-id: OC
         identifiers:
           - 4.1.2
@@ -169,8 +169,8 @@ controls:
           - 2.6
       - reference-id: SSDF
         identifiers:
-          - PO2
-          - PO3.2
+          - PO.2
+          - PO.3.2
       - reference-id: CSF
         identifiers:
           - PR.AA-02

--- a/baseline/OSPS-LE.yaml
+++ b/baseline/OSPS-LE.yaml
@@ -29,10 +29,10 @@ controls:
           - 1.2f
       - reference-id: SSDF
         identifiers:
-          - PO3.2
-          - PS1
-          - PW1.2
-          - PW2.1
+          - PO.3.2
+          - PS.1
+          - PW.1.2
+          - PW.2.1
     assessment-requirements:
       - id: OSPS-LE-01.01
         text: |
@@ -69,7 +69,7 @@ controls:
           - 1.2b
       - reference-id: SSDF
         identifiers:
-          - PO3.2
+          - PO.3.2
       - reference-id: CSF
         identifiers:
           - GV.OC-03
@@ -128,7 +128,7 @@ controls:
           - 1.2b
       - reference-id: SSDF
         identifiers:
-          - PO3.2
+          - PO.3.2
       - reference-id: ScCrd
         identifiers:
           - License          

--- a/baseline/OSPS-QA.yaml
+++ b/baseline/OSPS-QA.yaml
@@ -31,11 +31,11 @@ controls:
           - 1.2j
       - reference-id: SSDF
         identifiers:
-          - PS1
-          - PS2
-          - PS3
-          - PW1.2
-          - PW2.1
+          - PS.1
+          - PS.2
+          - PS.3
+          - PW.1.2
+          - PW.2.1
       - reference-id: OCRE
         identifiers:
           - 486-813
@@ -101,11 +101,11 @@ controls:
           - 2.3
       - reference-id: SSDF
         identifiers:
-          - PO3.3
-          - PS1
-          - PS2
-          - PS3.2
-          - PW4
+          - PO.3.3
+          - PS.1
+          - PS.2
+          - PS.3.2
+          - PW.4
       - reference-id: CSF
         identifiers:
           - ID.AM.01
@@ -164,10 +164,10 @@ controls:
           - 1.2k
       - reference-id: SSDF
         identifiers:
-          - PO4.1
-          - PS1
-          - PS2
-          - RV1.2
+          - PO.4.1
+          - PS.1
+          - PS.2
+          - RV.1.2
       - reference-id: CSF
         identifiers:
           - ID.IM-02
@@ -210,11 +210,11 @@ controls:
           - 1.2f
       - reference-id: SSDF
         identifiers:
-          - PO3.2
-          - PO4.1
-          - PS1
-          - PS2
-          - RV1.2
+          - PO.3.2
+          - PO.4.1
+          - PS.1
+          - PS.2
+          - RV.1.2
       - reference-id: OCRE
         identifiers:
           - 486-813
@@ -269,8 +269,8 @@ controls:
           - 1.2b
       - reference-id: SSDF
         identifiers:
-          - PS1
-          - PS2
+          - PS.1
+          - PS.2
       - reference-id: OCRE
         identifiers:
           - 486-813
@@ -312,7 +312,7 @@ controls:
           - 2.3
       - reference-id: SSDF
         identifiers:
-          - PW8.2
+          - PW.8.2
       - reference-id: CSF
         identifiers:
           - ID.AM-02

--- a/baseline/OSPS-SA.yaml
+++ b/baseline/OSPS-SA.yaml
@@ -29,7 +29,7 @@ controls:
         identifiers:
           - PO.1
           - PO.2
-          - PO3.2
+          - PO.3.2
       - reference-id: CSF
         identifiers:
           - ID.AM-02
@@ -76,7 +76,7 @@ controls:
           - 1.2b
       - reference-id: SSDF
         identifiers:
-          - PW1.2
+          - PW.1.2
       - reference-id: CSF
         identifiers:
           - GV.OC-05
@@ -126,8 +126,8 @@ controls:
           - 2.2
       - reference-id: SSDF
         identifiers:
-          - PO5.1
-          - PW1.1
+          - PO.5.1
+          - PW.1.1
       - reference-id: CSF
         identifiers:
           - ID.RA-01

--- a/baseline/OSPS-VM.yaml
+++ b/baseline/OSPS-VM.yaml
@@ -34,7 +34,7 @@ controls:
           - 2.8
       - reference-id: SSDF
         identifiers:
-          - RV1.3
+          - RV.1.3
       - reference-id: CSF
         identifiers:
           - GV.PO-01
@@ -86,7 +86,7 @@ controls:
           - 2.5
       - reference-id: SSDF
         identifiers:
-          - RV1.3
+          - RV.1.3
       - reference-id: CSF
         identifiers:
           - GV.PO-01
@@ -167,9 +167,9 @@ controls:
           - 2.6
       - reference-id: SSDF
         identifiers:
-          - PO4.1
-          - RV2.1
-          - RV2.2
+          - PO.4.1
+          - RV.2.1
+          - RV.2.2
       - reference-id: CSF
         identifiers:
           - ID.RA-01
@@ -240,12 +240,12 @@ controls:
       - reference-id: SSDF
         identifiers:
           - PO.4
-          - PW1.2
-          - PW8.1
-          - RV1.2
-          - RV1.3
-          - RV2.1
-          - RV 2.2
+          - PW.1.2
+          - PW.8.1
+          - RV.1.2
+          - RV.1.3
+          - RV.2.1
+          - RV.2.2
       - reference-id: CSF
         identifiers:
           - GV.RM-05
@@ -345,11 +345,11 @@ controls:
       - reference-id: SSDF
         identifiers:
           - PO.4
-          - PW1.2
-          - PW8.1
-          - RV1.2
-          - RV1.3
-          - RV2.1
+          - PW.1.2
+          - PW.8.1
+          - RV.1.2
+          - RV.1.3
+          - RV.2.1
           - RV 2.2
       - reference-id: CSF
         identifiers:


### PR DESCRIPTION
NIST SSDF uses the format `XX.0.0` (including a dot after the Section before the Practice.

Currently there's a mix of `.`, nothing and a whitespace. This PR normalizes it to use a dot as present in the NIST SSDF pdf.

![image](https://github.com/user-attachments/assets/d86a306d-d93d-435e-bd03-99c9228002f9)
