### PR TITLE
Add the standard LF disclaimer

### DIFF
--- a/docs/_layouts/default.html
+++ b/docs/_layouts/default.html
@@ -21,6 +21,8 @@ https://github.com/pages-themes/primer/blob/9990647c50551180ec28d60a3273214f2e27
       {{ content }}
 
       <div class="footer border-top border-gray-light mt-5 pt-3 text-right text-gray">
+        Copyright © OSPS Baseline contributors, a Series of LF Projects, LLC.
+        For website terms of use, trademark policy, and other project policies please see <a href="https://lfprojects.org">https://lfprojects.org</a>.
         This site is open source. View or contribute at <a href="{{ site.github.repository_url }}">GitHub</a>.
       </div>
     </div>


### PR DESCRIPTION
Addresses part of #245. Preview at: https://funnelfiasco.github.io/security-baseline/