### PR TITLE
Fix numbering of BR-01, BR-02 and BR-03 assessment requirements

### DIFF
--- a/docs/versions/2025-02-25.md
+++ b/docs/versions/2025-02-25.md
@@ -497,7 +497,7 @@ accessing privileged resources.
 
 
 
-#### OSPS-BR-01.01
+#### OSPS-BR-01.02
 
 **Requirement:** When a [CI/CD pipeline] uses a branch name in its functionality, that name value MUST be sanitized and validated prior to use in the pipeline. 
 
@@ -544,7 +544,7 @@ Examples include SemVer, CalVer, or git commit id.
 
 
 
-#### OSPS-BR-02.01
+#### OSPS-BR-02.02
 
 **Requirement:** When an official [release] is created, all assets within that [release] MUST be clearly associated with the [release] identifier or another unique identifier for the asset. 
 
@@ -596,7 +596,7 @@ only be accessed via encrypted channels.
 
 
 
-#### OSPS-BR-03.01
+#### OSPS-BR-03.02
 
 **Requirement:** When the project lists a URI as an official distribution channel, that URI MUST be exclusively delivered using encrypted channels. 
 


### PR DESCRIPTION
# Why was the change made?

https://baseline.openssf.org/versions/2025-02-25#build-and-release does not currently match the assessment requirement ID numbering in https://github.com/ossf/security-baseline/blob/18872dd469ee448de79fd2a38378fb985864e71d/baseline/OSPS-BR.yaml#L41

Originally discovered/noted in https://github.com/revanite-io/pvtr-github-repo/issues/11