### PR TITLE
Replace reporting with disclosure

### DIFF
--- a/baseline/OSPS-VM.yaml
+++ b/baseline/OSPS-VM.yaml
@@ -10,7 +10,7 @@ controls:
   - id: OSPS-VM-01
     title: |
         The project documentation MUST include a policy for coordinated
-        vulnerability reporting, with a clear timeframe for response.
+        vulnerability disclosure, with a clear timeframe for response.
     objective: |
       Establish a process for reporting and addressing vulnerabilities in the
       project, ensuring that security issues are handled promptly and 
@@ -56,15 +56,15 @@ controls:
       - id: OSPS-VM-01.01
         text: |
           While active, the project documentation MUST
-          include a policy for coordinated vulnerability reporting, with a clear
+          include a policy for coordinated vulnerability disclosure (CVD), with a clear
           timeframe for response.
         applicability:
           - Maturity Level 2
           - Maturity Level 3
         recommendation: |
           Create a SECURITY.md file at the root of the directory, outlining the
-          project's policy for coordinated vulnerability reporting. Include a
-          method for reporting vulnerabilities. Set expectations for the how the
+          project's policy for coordinated vulnerability disclosure. Include a
+          method for reporting vulnerabilities. Set expectations for how the
           project will respond and address reported issues.
 
   - id: OSPS-VM-02
@@ -139,7 +139,7 @@ controls:
       - id: OSPS-VM-03.01
         text: |
           While active, the project documentation MUST
-          provide a means for reporting security vulnerabilities privately to
+          provide a means for private vulnerability reporting directly to
           the security contacts within the project.
         applicability:
           - Maturity Level 2
@@ -147,7 +147,7 @@ controls:
         recommendation: |
           Provide a means for security researchers to report vulnerabilities
           privately to the project. This may be a dedicated email address, a
-          web form, VSC specialized tools, email addresses for security
+          web form, VCS specialized tools, email addresses for security
           contacts, or other methods.
 
   - id: OSPS-VM-04

--- a/baseline/lexicon.yaml
+++ b/baseline/lexicon.yaml
@@ -109,6 +109,18 @@
     details such as the modifications made, the
     contributor who made them, and the timestamp
     of the change.
+- term: Coordinated Vulnerability Disclosure
+  definition: |
+    A process of gathering information from vulnerability finders, coordinating
+    the sharing of that information between relevant stakeholders, and
+    disclosing the existence of software vulnerabilities and their mitigations
+    to various stakeholders including the public.
+  synonyms:
+    - CVD
+  references:
+    - https://certcc.github.io/CERT-Guide-to-CVD/
+    - https://www.first.org/global/sigs/vulnerability-coordination/multiparty/guidelines-v1-1
+    - https://docs.github.com/en/code-security/security-advisories/guidance-on-reporting-and-writing-information-about-vulnerabilities/about-coordinated-disclosure-of-security-vulnerabilities
 - term: Cyber Resilience Act
   definition: |
     Regulation (EU) 2024/2847 (Cyber Resilience Act, CRA).
@@ -232,6 +244,18 @@
     repositories will have the original repo
     acting as an equivalent to the primary
     branch.
+- term: Private Vulnerability Reporting
+  definition: |
+    The process of privately reporting a
+    vulnerability to the project maintainers or
+    security team before disclosing it publicly.
+    This allows the project to address the issue
+    before it becomes widely known.
+  synonyms:
+    - Private Vulnerability Disclosure
+    - Private Security Vulnerability Reporting
+  references:
+    - https://docs.github.com/en/code-security/security-advisories/guidance-on-reporting-and-writing-information-about-vulnerabilities/privately-reporting-a-security-vulnerability
 - term: Project Documentation
   definition: |
     Written materials related to the project,
@@ -382,4 +406,6 @@
     as well as tracking the resolution of these
     vulnerabilities.
   synonyms:
-    - Coordinated Vulnerability Reporting
+    - Coordinated Vulnerability Disclosure
+  references:
+    - https://docs.github.com/en/code-security/security-advisories/guidance-on-reporting-and-writing-information-about-vulnerabilities/privately-reporting-a-security-vulnerability


### PR DESCRIPTION
These changes are being made to close https://github.com/ossf/security-baseline/issues/64

 * Control descriptions and recommendations are updated to reference CVD
 * Lexicon entries and references are added related to the terms used