### PR TITLE
Document guiding principles for Baseline

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -17,3 +17,15 @@ Only the version labeled as "current" should be used for new compliance efforts.
 * [In-development version](versions/devel)
 
 Versions are managed according to the [Baseline maintenance process](maintenance).
+
+## Guiding principles
+
+The goal of the OSPS Baseline is to be useful to maintainers as a mechanism for evaluating and communicating a project's security posture.
+In addition, OSPS Baseline must help consumers of open source software more easily evaluate their compliance requirements.
+Therefore, OSPS Baseline work is:
+
+* **Focused:** Controls only contain *MUST* entries, not *SHOULD*.
+* **Realistic:** Controls are practical for project maintainers to implement at the appropriate level for their project.
+* **Actionable:** Controls provide specific recommendations.
+* **Meaningful:** Controls have an impact on a project's security posture.
+Ineffective controls add to maintainer burden.

--- a/docs/index.md
+++ b/docs/index.md
@@ -20,8 +20,9 @@ Versions are managed according to the [Baseline maintenance process](maintenance
 
 ## Guiding principles
 
-The goal of the OSPS Baseline is to be useful to maintainers as a mechanism for evaluating and communicating a project's security posture.
-In addition, OSPS Baseline must help consumers of open source software more easily evaluate their compliance requirements.
+The OSPS Baseline controls help project maintainers understand security best practices and expectations.
+Assessing a project's compliance against the controls helps maintainers and project consumers understand where the project excels at security and where it has room to improve.
+Project consumers can then use the assessment results to understand how their usage of the project impacts their own security and compliance goals.
 Therefore, OSPS Baseline work is:
 
 * **Focused:** Controls only contain *MUST* entries, not *SHOULD*.

--- a/governance/GOVERNANCE.md
+++ b/governance/GOVERNANCE.md
@@ -14,13 +14,7 @@ Refer to the [OpenSSF Community Calendar](https://openssf.org/getinvolved/) for 
 
 - **SIG Lead:** Eddie Knight (@eddie-knight)
 
-## Guiding Governance Principles
-
-Any issues or proposals brought to the project's maintainers shall be framed in the OSPS Baseline guiding principles. Proposals not adhering to said principles shall not be considered for consensus.
-
-### Favor Simplicity
-
-The goal of OSPS Baseline is to create a minimal and efficient standard that can be quickly ingested by any project. Simple is better.
+## Release Governance Principles
 
 ### Ensure Stability
 


### PR DESCRIPTION
These are a codification of things we've discussed, but not written down. The addition to `docs/index.md` is essentially an expansion of the item removed from `governance/GOVERNANCE.md`. What's left in `governance/GOVERNANCE.md` is now focused on releases.