### PR TITLE
Pass SIG leadership to Ben Cotton

### DIFF
--- a/governance/GOVERNANCE.md
+++ b/governance/GOVERNANCE.md
@@ -12,7 +12,7 @@ The Open Source Project Security Baseline (OSPS Baseline) is produced by the Ope
 
 Refer to the [OpenSSF Community Calendar](https://openssf.org/getinvolved/) for SIG meeting times, meeting notes, and links to past recordings.
 
-- **SIG Lead:** Eddie Knight (@eddie-knight)
+- **SIG Lead:** Ben Cotton (@funnnelfiasco)
 
 ## Guiding Governance Principles
 


### PR DESCRIPTION
Ben has been a singularly consistent force in the creation, maintenance, and advocacy for the OSPS Baseline. As I've become less active on the SIG to focus on ORBIT WG goals, I'm very happy to see Ben accept an official leadership role.

I will still continue to support the SIG as a maintainer/approver.