### PR TITLE
Setup golangci-lint

### DIFF
--- a/.cspell.yaml
+++ b/.cspell.yaml
@@ -8,8 +8,11 @@ dictionaryDefinitions:
 dictionaries:
   - project-words
 ignorePaths:
+  - '.cspell.yaml'
   - 'governance/'
   - '*.{csv,go,mod,scss,sum}'
   - 'CNAME'
   - 'LICENSE'
   - 'docs/versions/'
+  - '.github/workflows'
+  - '.golangci.yaml'

--- a/.github/workflows/golangci-lint.yaml
+++ b/.github/workflows/golangci-lint.yaml
@@ -1,0 +1,34 @@
+# SPDX-FileCopyrightText: Copyright 2025 The OSPS Baseline Authors
+# SPDX-License-Identifier: Apache-2.0
+---
+name: golangci-lint
+
+on:
+  workflow_dispatch: {}
+  pull_request:
+    branches:
+      - main
+
+permissions:
+  contents: read
+
+jobs:
+  golangci:
+    name: lint
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          persist-credentials: false
+
+      - uses: actions/setup-go@0aaccfd150d50ccaeb58ebd88d36e91967a5f35b # v5.4.0
+        with:
+          go-version: '1.24'
+          check-latest: true
+          cache: true
+
+      - name: Run golangci-lint
+        uses: golangci/golangci-lint-action@1481404843c368bc19ca9406f87d6e0fc97bdcfd # v7.0.0
+        with:
+          version: v2.1
+          working-directory: cmd

--- a/.project-words.txt
+++ b/.project-words.txt
@@ -6,12 +6,14 @@ exploitability
 FINOS
 Fintech
 Gesmer
+golangci
 incentivizing
 lifecycles
 openssf
 OCRE
 OSCAL
 OSPS
+PSSCRM
 remediations
 Shostack
 sigstore

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -20,6 +20,23 @@ title and descriptive commit message, PRs MUST meet the following criteria:
 * DCO signoff (via `git commit -s` -- [OSPS-LE-01](https://baseline.openssf.org/#osps-le-01))
 * All checks must pass ([OSPS-QA-04](https://baseline.openssf.org/#osps-qa-04))
 
+### Check Go Tooling Linter
+
+The OSPS Baseline tools are written in Go and the repository enforces linting on
+every pull request. Before opening a PR, you can test your changes make the linter
+happy by running [golangci-lint](https://golangci-lint.run/) locally in
+the `cmd/` directory:
+
+```bash
+cd cmd/
+golangci-lint run
+```
+
+### CSpell Check and Dictionary
+
+The repo will enforce spell checks across the codebase. If you introduce new words
+that the spell checker does not recognize, just add them to the `.cspell.yaml` file.
+
 ## Maintainer Status
 
 See [./governance/GOVERNANCE.md](./governance/GOVERNANCE.md#maintainer-status) for

--- a/baseline/OSPS-AC.yaml
+++ b/baseline/OSPS-AC.yaml
@@ -96,7 +96,7 @@ controls:
           - 802-056
           - 368-633
           - 152-725
-       - reference-id: PSSCRM
+      - reference-id: PSSCRM
         identifiers: 
           - P2.3
           - E1.2
@@ -146,13 +146,13 @@ controls:
       - reference-id: ScCrd
         identifiers:
           - Branch-Protection 
-       - reference-id: PSSCRM
+      - reference-id: PSSCRM
         identifiers: 
           - P3.2
           - P3.5
           - E1.5
           - E3.1
-       assessment-requirements:
+    assessment-requirements:
       - id: OSPS-AC-03.01
         text: |
           When a direct commit is attempted on the project's primary branch,

--- a/baseline/OSPS-BR.yaml
+++ b/baseline/OSPS-BR.yaml
@@ -312,7 +312,7 @@ controls:
           - E2.3
           - E2.4
           - E2.5
-       assessment-requirements:
+    assessment-requirements:
       - id: OSPS-BR-05.01
         text: |
           When a build and release pipeline ingests dependencies, it MUST

--- a/baseline/OSPS-DO.yaml
+++ b/baseline/OSPS-DO.yaml
@@ -151,7 +151,7 @@ controls:
           - P3.2
           - P3.3
           - E2.6
-      assessment-requirements:
+    assessment-requirements:
       - id: OSPS-DO-03.01
         text: |
           When the project has made a release, the project documentation MUST
@@ -293,7 +293,7 @@ controls:
           - P3.1
           - P3.2
           - P3.4
-      assessment-requirements:
+    assessment-requirements:
       - id: OSPS-DO-06.01
         text: |
           When the project has made a release, the project documentation MUST

--- a/baseline/OSPS-QA.yaml
+++ b/baseline/OSPS-QA.yaml
@@ -56,7 +56,7 @@ controls:
         identifiers: 
           - P3.5
           - E2.2
-       assessment-requirements:
+    assessment-requirements:
       - id: OSPS-QA-01.01
         text: |
           While active, the project's source code repository MUST be publicly
@@ -136,7 +136,7 @@ controls:
           - P5.2
           - E2.1
           - E2.2
-       assessment-requirements:
+    assessment-requirements:
       - id: OSPS-QA-02.01
         text: |
           When the package management system supports it, the source code
@@ -201,7 +201,7 @@ controls:
           - P3.5
           - P4.1
           - P4.2
-       assessment-requirements:
+    assessment-requirements:
       - id: OSPS-QA-03.01
         text: |
           When a commit is made to the primary branch, any automated status
@@ -375,7 +375,7 @@ controls:
           - P4.4
           - E2.4
           - E2.5
-       assessment-requirements:
+    assessment-requirements:
       - id: OSPS-QA-06.01
         text: |
           Prior to a commit being accepted, the project's CI/CD pipelines MUST
@@ -436,7 +436,7 @@ controls:
           - G2.4
           - P3.3
           - P3.5
-       assessment-requirements:
+    assessment-requirements:
       - id: OSPS-QA-07.01
         text: |
           When a commit is made to the primary branch, the project's version

--- a/baseline/OSPS-SA.yaml
+++ b/baseline/OSPS-SA.yaml
@@ -46,7 +46,7 @@ controls:
           - P1.1
           - E3.4
           - E3.7
-      assessment-requirements:
+    assessment-requirements:
       - id: OSPS-SA-01.01
         text: |
           When the project has made a release, the project documentation MUST
@@ -157,7 +157,7 @@ controls:
           - G4.3
           - G5.2
           - P2.1
-      assessment-requirements:
+    assessment-requirements:
       - id: OSPS-SA-03.01
         text: |
           When the project has made a release, the project MUST perform a

--- a/baseline/OSPS-VM.yaml
+++ b/baseline/OSPS-VM.yaml
@@ -58,7 +58,7 @@ controls:
           - D1.2
           - D1.3
           - D1.5
-     assessment-requirements:
+    assessment-requirements:
       - id: OSPS-VM-01.01
         text: |
           While active, the project documentation MUST
@@ -186,7 +186,7 @@ controls:
         identifiers: 
           - G2.2
           - D1.1
-     assessment-requirements:
+    assessment-requirements:
       - id: OSPS-VM-04.01
         text: |
           While active, the project documentation MUST
@@ -292,7 +292,7 @@ controls:
           - P4.3
           - P4.4
           - P4.5
-     assessment-requirements:
+    assessment-requirements:
       - id: OSPS-VM-05.01
         text: |
           While active, the project documentation MUST include a policy that

--- a/cmd/.golangci.yaml
+++ b/cmd/.golangci.yaml
@@ -1,0 +1,182 @@
+# SPDX-FileCopyrightText: Copyright 2025 The OSPS Baseline Authors
+# SPDX-License-Identifier: Apache-2.0
+---
+version: "2"
+run:
+  concurrency: 6
+  timeout: 5m
+issues:
+  # Maximum issues count per one linter. Set to 0 to disable. Default is 50.
+  max-issues-per-linter: 0
+
+  # Maximum count of issues with the same text. Set to 0 to disable. Default is 3.
+  max-same-issues: 0
+formatters:
+  # Enable specific formatter.
+  # Default: [] (uses standard Go formatting)
+  enable:
+    - gci
+    - gofmt
+    - gofumpt
+    - goimports
+    # - golines
+  settings: 
+    gci:
+      no-inline-comments: false
+      no-prefix-comments: true
+      sections:
+        - standard
+        - default
+        - prefix(github.com/ossf/security-baseline)
+linters:
+  enable:
+    - asasalint
+    - asciicheck
+    - bidichk
+    - bodyclose
+    - canonicalheader
+    - containedctx
+    - contextcheck
+    - copyloopvar
+    - decorder
+    - dogsled
+    - dupl
+    - durationcheck
+    - errcheck
+    - errchkjson
+    - errname
+    - errorlint
+    - exhaustive
+    - exptostd
+    - fatcontext
+    - forcetypeassert
+    - ginkgolinter
+    - gocheckcompilerdirectives
+    - gochecksumtype
+    - goconst
+    - gocritic
+    - gocyclo
+    # - godot
+    - godox
+    - goheader
+    - gomoddirectives
+    - gomodguard
+    - goprintffuncname
+    - gosec
+    - gosmopolitan
+    - govet
+    - grouper
+    - iface
+    - importas
+    - ineffassign
+    - intrange
+    - loggercheck
+    - makezero
+    - mirror
+    - misspell
+    - musttag
+    - nakedret
+    - nilerr
+    - nilnesserr
+    # - nlreturn
+    - noctx
+    - nolintlint
+    - nosprintfhostport
+    # - perfsprint
+    - prealloc
+    - predeclared
+    - promlinter
+    # - protogetter
+    - reassign
+    - recvcheck
+    # - revive
+    - rowserrcheck
+    - sloglint
+    - spancheck
+    - sqlclosecheck
+    - staticcheck
+    - tagalign
+    - testableexamples
+    - testifylint
+    - tparallel
+    - unconvert
+    - unparam
+    - unused
+    - usestdlibvars
+    - usetesting
+    - wastedassign
+    - whitespace
+    # - wsl
+    - zerologlint
+
+  settings:
+    gocyclo:
+      min-complexity: 35
+    godox:
+      keywords:
+        - BUG
+        - FIXME
+        - HACK
+    gosmopolitan:
+      # Allow and ignore `time.Local` usages.
+      #
+      # Default: false
+      allow-time-local: true
+    perfsprint:
+      integer-format: false
+    errcheck:
+      check-type-assertions: true
+      check-blank: true
+    gocritic:
+      enabled-checks:
+        # Diagnostic
+        - commentedOutCode
+        - nilValReturn
+        - sloppyReassign
+        - weakCond
+        - octalLiteral
+
+        # Performance
+        - appendCombine
+        - equalFold
+        - hugeParam
+        - indexAlloc
+        - rangeExprCopy
+        - rangeValCopy
+
+        # Style
+        - boolExprSimplify
+        - commentedOutImport
+        - docStub
+        - emptyFallthrough
+        - emptyStringTest
+        - hexLiteral
+        - methodExprCall
+        - stringXbytes
+        - typeAssertChain
+        - unlabelStmt
+        - yodaStyleExpr
+
+        # Opinionated
+        - builtinShadow
+        - importShadow
+        - initClause
+        - nestingReduce
+        - paramTypeCombine
+        - ptrToRefParam
+        - typeUnparen
+        - unnamedResult
+        - unnecessaryBlock
+    gosec:
+      excludes:
+        - G304
+    nolintlint:
+      # Enable to ensure that nolint directives are all used. Default is true.
+      allow-unused: false
+      # Exclude following linters from requiring an explanation.  Default is [].
+      allow-no-explanation: []
+      # Enable to require an explanation of nonzero length after each nolint directive. Default is false.
+      # TODO(lint): Enforce explanations for `nolint` directives
+      require-explanation: false
+      # Enable to require nolint directives to mention the specific linter being suppressed. Default is false.
+      require-specific: true

--- a/cmd/go.mod
+++ b/cmd/go.mod
@@ -1,6 +1,6 @@
 module github.com/ossf/security-baseline
 
-go 1.23
+go 1.24
 
 require (
 	github.com/defenseunicorns/go-oscal v0.6.2

--- a/cmd/internal/cmd/compile.go
+++ b/cmd/internal/cmd/compile.go
@@ -8,8 +8,9 @@ import (
 	"fmt"
 	"os"
 
-	"github.com/ossf/security-baseline/pkg/baseline"
 	"github.com/spf13/cobra"
+
+	"github.com/ossf/security-baseline/pkg/baseline"
 )
 
 type compileOptions struct {
@@ -18,7 +19,6 @@ type compileOptions struct {
 	baselinePath          string
 	checklistTemplatePath string
 	templatePath          string
-	checklist             bool
 	validate              bool
 }
 

--- a/cmd/internal/cmd/oscal.go
+++ b/cmd/internal/cmd/oscal.go
@@ -8,8 +8,9 @@ import (
 	"fmt"
 	"os"
 
-	"github.com/ossf/security-baseline/pkg/baseline"
 	"github.com/spf13/cobra"
+
+	"github.com/ossf/security-baseline/pkg/baseline"
 )
 
 var appname = "baseline"

--- a/cmd/internal/cmd/root.go
+++ b/cmd/internal/cmd/root.go
@@ -9,8 +9,8 @@ func Execute() error {
 	rootCmd := &cobra.Command{
 		Use:  "baseline-compiler",
 		Long: `Baseline Compiler reads the Basline YAML and outputs it as a markdown document.`,
-		Run: func(cmd *cobra.Command, args []string) {
-			cmd.Help() //nolint
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return cmd.Help()
 		},
 	}
 

--- a/cmd/internal/cmd/validate.go
+++ b/cmd/internal/cmd/validate.go
@@ -8,8 +8,9 @@ import (
 	"fmt"
 	"os"
 
-	"github.com/ossf/security-baseline/pkg/baseline"
 	"github.com/spf13/cobra"
+
+	"github.com/ossf/security-baseline/pkg/baseline"
 )
 
 type validateOptions struct {
@@ -30,7 +31,6 @@ func (o *validateOptions) AddFlags(cmd *cobra.Command) {
 	cmd.PersistentFlags().StringVarP(
 		&o.baselinePath, "baseline", "b", "", "path to directory containing the baseline YAML definitions",
 	)
-
 }
 
 // addValidate adds the compile subcommand to the parent command

--- a/cmd/pkg/baseline/generator.go
+++ b/cmd/pkg/baseline/generator.go
@@ -16,11 +16,10 @@ func NewGenerator() *Generator {
 	return &Generator{}
 }
 
-type Generator struct {
-}
+type Generator struct{}
 
 // ExportMarkdown runs the baseline data through the markdown template
-func (g *Generator) ExportMarkdown(b *types.Baseline, templatePath string, path string) error {
+func (g *Generator) ExportMarkdown(b *types.Baseline, templatePath, path string) error {
 	// Read the markdown template from the external file
 	templateContent, err := os.ReadFile(templatePath)
 	if err != nil {
@@ -28,7 +27,7 @@ func (g *Generator) ExportMarkdown(b *types.Baseline, templatePath string, path 
 	}
 
 	// Open or create the output file
-	if err := os.MkdirAll(filepath.Dir(path), os.ModePerm); err != nil {
+	if err := os.MkdirAll(filepath.Dir(path), os.FileMode(0o750)); err != nil {
 		return fmt.Errorf("error creating output directory %s: %w", filepath.Dir(path), err)
 	}
 
@@ -36,7 +35,7 @@ func (g *Generator) ExportMarkdown(b *types.Baseline, templatePath string, path 
 	if err != nil {
 		return fmt.Errorf("error creating output file %s: %w", path, err)
 	}
-	defer outputFile.Close()
+	defer outputFile.Close() //nolint:errcheck
 
 	// Create and parse the template
 	tmpl, err := template.New("baseline").Funcs(template.FuncMap{

--- a/cmd/pkg/baseline/generator_oscal.go
+++ b/cmd/pkg/baseline/generator_oscal.go
@@ -11,6 +11,7 @@ import (
 	"time"
 
 	oscal "github.com/defenseunicorns/go-oscal/src/types/oscal-1-1-3"
+
 	"github.com/ossf/security-baseline/pkg/types"
 )
 
@@ -56,7 +57,6 @@ func (g *Generator) ExportOSCAL(b *types.Baseline, w io.Writer) error {
 		controls := []oscal.Control{}
 
 		for _, control := range cat.Controls {
-
 			parts := []oscal.Part{}
 			for _, ar := range control.Requirements {
 				parts = append(parts, oscal.Part{
@@ -105,7 +105,7 @@ func (g *Generator) ExportOSCAL(b *types.Baseline, w io.Writer) error {
 
 	// Wrap the catalog to render the required "catalog" wrapper
 	// in the JSON file:
-	var wrapper = struct {
+	wrapper := struct {
 		Catalog oscal.Catalog `json:"catalog"`
 	}{
 		Catalog: catalog,

--- a/cmd/pkg/baseline/loader.go
+++ b/cmd/pkg/baseline/loader.go
@@ -8,12 +8,15 @@ import (
 	"os"
 	"path/filepath"
 
-	"github.com/ossf/security-baseline/pkg/types"
 	"gopkg.in/yaml.v3"
+
+	"github.com/ossf/security-baseline/pkg/types"
 )
 
-const LexiconFilename = "lexicon.yaml"
-const FrameworksFilename = "frameworks.yaml"
+const (
+	LexiconFilename    = "lexicon.yaml"
+	FrameworksFilename = "frameworks.yaml"
+)
 
 // Loader is an object that reads the baseline data
 type Loader struct {
@@ -51,7 +54,6 @@ func (l *Loader) Load() (*types.Baseline, error) {
 		b.Categories[catCode] = *cat
 	}
 
-	// return b, b.validate()
 	return b, nil
 }
 
@@ -61,14 +63,14 @@ func (l *Loader) loadLexicon() ([]types.LexiconEntry, error) {
 	if err != nil {
 		return nil, fmt.Errorf("error opening file: %w", err)
 	}
-	defer file.Close()
+	defer file.Close() //nolint:errcheck
 
 	var lexicon []types.LexiconEntry
 
 	decoder := yaml.NewDecoder(file)
 	decoder.KnownFields(true)
 	if err := decoder.Decode(&lexicon); err != nil {
-		return nil, fmt.Errorf("error decoding YAML: %v", err)
+		return nil, fmt.Errorf("error decoding YAML: %w", err)
 	}
 	return lexicon, nil
 }
@@ -79,14 +81,14 @@ func (l *Loader) loadFramework() ([]types.FrameworkEntry, error) {
 	if err != nil {
 		return nil, fmt.Errorf("error opening file: %w", err)
 	}
-	defer file.Close()
+	defer file.Close() //nolint:errcheck
 
 	var frameworks types.Frameworks
 
 	decoder := yaml.NewDecoder(file)
 	decoder.KnownFields(true)
 	if err := decoder.Decode(&frameworks); err != nil {
-		return nil, fmt.Errorf("error decoding YAML: %v", err)
+		return nil, fmt.Errorf("error decoding YAML: %w", err)
 	}
 	return frameworks.Frameworks, nil
 }
@@ -95,11 +97,11 @@ func (l *Loader) loadFramework() ([]types.FrameworkEntry, error) {
 func (l *Loader) loadCategory(catCode string) (*types.Category, error) {
 	file, err := os.Open(filepath.Join(l.DataPath, fmt.Sprintf("OSPS-%s.yaml", catCode)))
 	if err != nil {
-		return nil, fmt.Errorf("error opening file: %v", err)
+		return nil, fmt.Errorf("error opening file: %w", err)
 	}
-	defer file.Close()
+	defer file.Close() //nolint:errcheck
 
-	var category = &types.Category{}
+	category := &types.Category{}
 
 	decoder := yaml.NewDecoder(file)
 	decoder.KnownFields(true)

--- a/cmd/pkg/baseline/template-functions.go
+++ b/cmd/pkg/baseline/template-functions.go
@@ -29,8 +29,11 @@ func containsSynonym(list []string, entryTerm, term string) bool {
 }
 
 // Check whether there's an unmatched open bracket before the term
-func isWrapped(text string, matched string) bool {
+func isWrapped(text, matched string) bool {
 	beforeIndex := strings.Index(text, matched)
+	if beforeIndex == -1 {
+		return true
+	}
 	substrBeforeTerm := text[:beforeIndex]
 
 	openBrackets := strings.Count(substrBeforeTerm, "[")
@@ -56,7 +59,7 @@ func addLinks(lexicon []types.LexiconEntry, text, term string) string {
 
 		for i, entry := range lexicon {
 			if entry.Term == term && !containsSynonym(entry.Synonyms, entry.Term, matched) {
-				lexicon[i].Synonyms = append(entry.Synonyms, matched)
+				lexicon[i].Synonyms = append(entry.Synonyms, matched) //nolint:gocritic
 			}
 		}
 		return fmt.Sprintf("[%s]", matched)

--- a/cmd/pkg/baseline/validator.go
+++ b/cmd/pkg/baseline/validator.go
@@ -15,13 +15,12 @@ func NewValidator() *Validator {
 	return &Validator{}
 }
 
-type Validator struct {
-}
+type Validator struct{}
 
 // Check verifies the data parsed for consistency and completeness
 func (v *Validator) Check(b *types.Baseline) error {
 	var entryIDs []string
-	var errs = []error{}
+	errs := []error{}
 	for _, category := range b.Categories {
 		for _, entry := range category.Controls {
 			if slices.Contains(entryIDs, entry.ID) {


### PR DESCRIPTION
This PR adds a presubmit to run golangci-lint on the codebase and fixes the errors detected by the linter.

A second commit adds a presubmit check to run the linter on every PR.




Signed-off-by: Adolfo García Veytia (Puerco) <puerco@carabiner.dev>
