### PR TITLE
Split spell checking into a separate workflow

### DIFF
--- a/.github/workflows/spellcheck.yml
+++ b/.github/workflows/spellcheck.yml
@@ -1,0 +1,21 @@
+name: Spell check
+
+on:
+    pull_request:
+  
+permissions:
+    contents: read
+
+jobs:
+    spellcheck:
+        runs-on: ubuntu-latest
+        steps:
+          - name: Checkout
+            uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+            with:
+                persist-credentials: false
+    
+          - name: Spellcheck all content
+            uses: streetsidesoftware/cspell-action@357d91b7153520efd453f404d76424cff0a29797 # v6.11.0
+            with:
+              config: .cspell.yaml       

--- a/.github/workflows/test-build.yml
+++ b/.github/workflows/test-build.yml
@@ -17,11 +17,6 @@ jobs:
         with:
             persist-credentials: false
 
-      - name: Spellcheck all content
-        uses: streetsidesoftware/cspell-action@357d91b7153520efd453f404d76424cff0a29797 # v6.11.0
-        with:
-          config: .cspell.yaml
-
       - name: Build content from yaml
         run:  cd cmd && go run . compile --output ../docs/versions/devel.md
 


### PR DESCRIPTION
Run the spellcheck separately from the build so that it makes CI failures more immediately clear (and gives us the option to make build failures blocking but have spelling failures be not-blocking later if we so choose. I am not advocating that, just noting that it gives us the option)

Signed-off-by: Ben Cotton <ben@kusari.dev>