### PR TITLE
Even baseline path in all commands

### DIFF
--- a/cmd/internal/cmd/compile.go
+++ b/cmd/internal/cmd/compile.go
@@ -34,7 +34,7 @@ func (o *compileOptions) Validate() error {
 
 func (o *compileOptions) AddFlags(cmd *cobra.Command) {
 	cmd.PersistentFlags().StringVarP(
-		&o.baselinePath, "baseline", "b", "../baseline", "path to directory containing the baseline YAML data",
+		&o.baselinePath, "baseline", "b", defaultBaselinePath, "path to directory containing the baseline YAML data",
 	)
 
 	cmd.PersistentFlags().StringVarP(

--- a/cmd/internal/cmd/oscal.go
+++ b/cmd/internal/cmd/oscal.go
@@ -32,7 +32,7 @@ func (o *oscalOptions) Validate() error {
 
 func (o *oscalOptions) AddFlags(cmd *cobra.Command) {
 	cmd.PersistentFlags().StringVarP(
-		&o.baselinePath, "baseline", "b", "", "path to directory containing the baseline YAML data",
+		&o.baselinePath, "baseline", "b", defaultBaselinePath, "path to directory containing the baseline YAML data",
 	)
 
 	cmd.PersistentFlags().StringVarP(

--- a/cmd/internal/cmd/root.go
+++ b/cmd/internal/cmd/root.go
@@ -5,6 +5,12 @@ package cmd
 
 import "github.com/spf13/cobra"
 
+const (
+	// defaultBaselinePath is the default location where the CLI will look for
+	// the baseline YAML files
+	defaultBaselinePath = "../baseline"
+)
+
 func Execute() error {
 	rootCmd := &cobra.Command{
 		Use:  "baseline-compiler",

--- a/cmd/internal/cmd/validate.go
+++ b/cmd/internal/cmd/validate.go
@@ -29,7 +29,7 @@ func (o *validateOptions) Validate() error {
 
 func (o *validateOptions) AddFlags(cmd *cobra.Command) {
 	cmd.PersistentFlags().StringVarP(
-		&o.baselinePath, "baseline", "b", "", "path to directory containing the baseline YAML definitions",
+		&o.baselinePath, "baseline", "b", defaultBaselinePath, "path to directory containing the baseline YAML definitions",
 	)
 }
 


### PR DESCRIPTION
This PRs introduces a default path constant with the path to look for the baseline YAML files. It is now shared across all subcommands.



Closes https://github.com/ossf/security-baseline/issues/281

Signed-off-by: Adolfo García Veytia (Puerco) <puerco@carabiner.dev>