### PR TITLE
Add Evan Anderson as a maintainer

### DIFF
--- a/governance/MAINTAINERS.md
+++ b/governance/MAINTAINERS.md
@@ -7,6 +7,7 @@
 - Christopher "CRob" Robinson, OpenSSF (@SecurityCRob)
 - David A Wheeler, OpenSSF (@david-a-wheeler)
 - Ben Cotton, Kusari (@funnelfiasco)
+- Evan Anderson, Stacklok (@evankanderson)
 
 ## Emeritus Maintainers
 


### PR DESCRIPTION
In accordance with the [project governance](https://github.com/ossf/security-baseline/blob/main/governance/GOVERNANCE.md), @eddie-knight and I are forming a sponsoring committee to nominate @evankanderson as a maintainer of the OSPS Baseline.

Evan has made considerable contributions to this project via [pull requests](https://github.com/ossf/security-baseline/pulls?q=is%3Apr+author%3Aevankanderson) as well as conversations in issues, pull requests, and meetings.