### PR TITLE
docs: clarify that contribs come from humans and non-humans

### DIFF
--- a/baseline/OSPS-AC.yaml
+++ b/baseline/OSPS-AC.yaml
@@ -10,7 +10,7 @@ controls:
   - id: OSPS-AC-01
     title: |
       The project's version control system MUST require multi-factor
-      authentication for collaborators modifying the project repository
+      authentication for users modifying the project repository
       settings or accessing sensitive data.
     objective: |
       Reduce the risk of account compromise or insider threats by requiring

--- a/baseline/lexicon.yaml
+++ b/baseline/lexicon.yaml
@@ -75,9 +75,9 @@
 - term: Contributor
   definition: |
     Entities who commit code or documentation to
-    the project. Code contributors include
-    collaborators or external participants who
-    submit changes.
+    the project. This includes both human
+    and non-human actors and makes no distinctions
+    based on their role within the project.
 
     In the context of the Open Source Project
     Security Baseline, code contributors does not
@@ -94,10 +94,9 @@
     the primary deliverable in a release.
 - term: Collaborator
   definition: |
-    A user with a role on the project's version
-    control system who can approve changes or
-    manage the repository settings. Collaborators
-    may have varying permission levels based on
+    A human or non-human entity with permissions to
+    approve changes or manage the repository settings.
+    Collaborators may have varying permission levels based on
     their role in the project. This does not
     include contributors whose changes only
     originate through a request from a repository

--- a/baseline/lexicon.yaml
+++ b/baseline/lexicon.yaml
@@ -448,6 +448,14 @@
     recommended formats are Semantic Versioning
     or Calendar Versioning.
   synonyms:
+- term: User
+  definition: |
+    A human making use of project resources, such as
+    the software, documentation, or other community
+    resources. This includes both end-users and
+    contributors.
+  synonyms:
+    - Person
 - term: Version Control System
   definition: |
     A tool that tracks changes to files over time


### PR DESCRIPTION
Adding language to clarify that non-human actors play a role in the SDLC and that those activities are treated equally to human actor activities within the context of the baseline

This updates https://github.com/ossf/security-baseline/issues/275