### PR TITLE
fix: render the framework mapping references in docs

### DIFF
--- a/baseline/OSPS-AC.yaml
+++ b/baseline/OSPS-AC.yaml
@@ -16,7 +16,7 @@ controls:
       Reduce the risk of account compromise or insider threats by requiring
       multi-factor authentication for collaborators modifying the project
       repository settings or accessing sensitive data.
-    mappings:
+    guideline-mappings:
       - reference-id: BPB
         identifiers:
           - CC-G-1
@@ -43,7 +43,7 @@ controls:
           - 152-725
           - 201-246
       - reference-id: PSSCRM
-        identifiers: 
+        identifiers:
           - G2.6
           - P3.3
           - E1.2
@@ -51,10 +51,10 @@ controls:
           - E1.4
           - E3.1
       - reference-id: SAMM
-        identifiers: 
+        identifiers:
           - Operations -Environment Management -Configuration Hardening Lvl1
       - reference-id: PCIDSS
-        identifiers: 
+        identifiers:
           - 2.2.1
           - 8.2.1
           - 8.3.1
@@ -81,7 +81,7 @@ controls:
     objective: |
       Reduce the risk of unauthorized access to the project's repository by
       limiting the permissions granted to new collaborators.
-    mappings:
+    guideline-mappings:
       - reference-id: CRA
         identifiers:
           - 1.2f
@@ -103,12 +103,12 @@ controls:
           - 368-633
           - 152-725
       - reference-id: PSSCRM
-        identifiers: 
+        identifiers:
           - P2.3
           - E1.2
           - E3.3
       - reference-id: PCIDSS
-        identifiers: 
+        identifiers:
           - 2.2.1
     assessment-requirements:
       - id: OSPS-AC-02.01
@@ -133,7 +133,7 @@ controls:
     objective: |
       Reduce the risk of accidental changes or deletion of the primary branch
       of the project's repository by preventing unintentional modification.
-    mappings:
+    guideline-mappings:
       - reference-id: CRA
         identifiers:
           - 1.2f
@@ -153,15 +153,15 @@ controls:
           - 152-725
       - reference-id: ScCrd
         identifiers:
-          - Branch-Protection 
+          - Branch-Protection
       - reference-id: PSSCRM
-        identifiers: 
+        identifiers:
           - P3.2
           - P3.5
           - E1.5
           - E3.1
       - reference-id: PCIDSS
-        identifiers: 
+        identifiers:
           - 2.2.1
     assessment-requirements:
       - id: OSPS-AC-03.01
@@ -199,7 +199,7 @@ controls:
       Reduce the risk of unauthorized access to the project's build and release
       processes by limiting the permissions granted to steps within the CI/CD
       pipelines.
-    mappings:
+    guideline-mappings:
       - reference-id: CRA
         identifiers:
           - 1.2d
@@ -227,13 +227,13 @@ controls:
           - Producer - Choose an appropriate build platform
           - Build platform - Isolation strength - Isolated
       - reference-id: PSSCRM
-        identifiers: 
-          - P3.2   
+        identifiers:
+          - P3.2
       - reference-id: SAMM
-        identifiers: 
+        identifiers:
           - Operations -Environment Management -Configuration Hardening Lvl1
       - reference-id: PCIDSS
-        identifiers: 
+        identifiers:
           - 2.2.1
           - 8.2.1
     assessment-requirements:

--- a/baseline/OSPS-BR.yaml
+++ b/baseline/OSPS-BR.yaml
@@ -16,7 +16,7 @@ controls:
       Reduce the risk of code injection or other security vulnerabilities in the
       project's build and release pipelines by preventing untrusted input from
       accessing privileged resources.
-    mappings:
+    guideline-mappings:
       - reference-id: CRA
         identifiers:
           - 1.2f
@@ -38,15 +38,15 @@ controls:
         identifiers:
           - Choose an appropriate build platform
       - reference-id: PSSCRM
-        identifiers: 
+        identifiers:
           - P2.3
           - P3.2
           - P3.5
           - E2.4
           - E2.5
-          - D2.2       
+          - D2.2
       - reference-id: PCIDSS
-        identifiers: 
+        identifiers:
           - 2.2.1
           - 6.4.1
     assessment-requirements:
@@ -78,7 +78,7 @@ controls:
       Ensure that each software asset produced by the project is uniquely
       identified, enabling users to track changes and updates to the project
       over time.
-    mappings:
+    guideline-mappings:
       - reference-id: BPB
         identifiers:
           - CC-B-5
@@ -102,13 +102,13 @@ controls:
           - Follow a consistent build process
           - Provenance generation- Exists, Authentic
       - reference-id: PSSCRM
-        identifiers: 
+        identifiers:
           - G1.4
           - E1.2
           - E2.1
-          - E2.6   
+          - E2.6
       - reference-id: PCIDSS
-        identifiers: 
+        identifiers:
           - 6.4.3
     assessment-requirements:
       - id: OSPS-BR-02.01
@@ -140,7 +140,7 @@ controls:
     objective: |
       Protect the confidentiality and integrity of project source code during
       development, reducing the risk of eavesdropping or data tampering.
-    mappings:
+    guideline-mappings:
       - reference-id: BPB
         identifiers:
           - B-B-11
@@ -167,13 +167,13 @@ controls:
         identifiers:
           - Choose an appropriate build platform
       - reference-id: PSSCRM
-        identifiers: 
+        identifiers:
           - E1.1
           - E2.2
           - E2.4
-          - E2.5   
+          - E2.5
       - reference-id: PCIDSS
-        identifiers: 
+        identifiers:
           - 2.2.1
           - 2.2.7
           - 4.2.1
@@ -215,7 +215,7 @@ controls:
       Provide transparency and accountability for changes made to the project's
       software releases, enabling users to understand the modifications and
       improvements included in each release.
-    mappings:
+    guideline-mappings:
       - reference-id: BPB
         identifiers:
           - CC-B-8
@@ -254,7 +254,7 @@ controls:
           - Follow a consistent build process
           - Build platform - Isolation strength - isolated
       - reference-id: PSSCRM
-        identifiers: 
+        identifiers:
           - G1.4
           - E2.1
           - E2.4
@@ -262,7 +262,7 @@ controls:
           - E3.1
           - E3.6
       - reference-id: PCIDSS
-        identifiers: 
+        identifiers:
           - 6.2.1
           - 6.4.1
           - 6.5.1
@@ -293,7 +293,7 @@ controls:
       Ensure that the project's build and release pipelines use standardized tools
       and processes to manage dependencies, reducing the risk of compatibility
       issues or security vulnerabilities in the software.
-    mappings:
+    guideline-mappings:
       - reference-id: BPB
         identifiers:
           - Q-B-2
@@ -322,7 +322,7 @@ controls:
         identifiers:
           - Isolation strength - isolated
       - reference-id: PSSCRM
-        identifiers: 
+        identifiers:
           - P3.1
           - P3.5
           - E2.2
@@ -330,10 +330,10 @@ controls:
           - E2.4
           - E2.5
       - reference-id: SAMM
-        identifiers: 
+        identifiers:
           - Implementation -Secure Build -Build Process Lvl2
       - reference-id: PCIDSS
-        identifiers: 
+        identifiers:
           - 6.4.3
     assessment-requirements:
       - id: OSPS-BR-05.01
@@ -356,7 +356,7 @@ controls:
     objective: |
       All released software assets MUST be signed or accounted for in a
       signed manifest including each asset's cryptographic hashes.
-    mappings:
+    guideline-mappings:
       - reference-id: SSDF
         identifiers:
           - PO.5.2
@@ -370,7 +370,7 @@ controls:
         identifiers:
           - Distribute provenance - Exists
       - reference-id: PSSCRM
-        identifiers: 
+        identifiers:
           - P1.2
           - P3.2
           - P3.3
@@ -378,10 +378,10 @@ controls:
           - E2.2
           - E2.6
       - reference-id: SAMM
-        identifiers: 
+        identifiers:
           - Implementation -Secure Deployment -Deployment Process Lvl3
       - reference-id: PCIDSS
-        identifiers: 
+        identifiers:
           - 2.2.1
           - 2.2.7
           - 3.5.1

--- a/baseline/OSPS-DO.yaml
+++ b/baseline/OSPS-DO.yaml
@@ -16,7 +16,7 @@ controls:
       Ensure that users have a clear and comprehensive understanding of the
       project's current features in order to prevent damage from misuse or
       misconfiguration.
-    mappings:
+    guideline-mappings:
       - reference-id: BPB
         identifiers:
           - B-B-1
@@ -42,11 +42,11 @@ controls:
         identifiers:
           - 036-275
       - reference-id: PSSCRM
-        identifiers: 
+        identifiers:
           - G5.1
-          - E3.5  
+          - E3.5
       - reference-id: PCIDSS
-        identifiers: 
+        identifiers:
           - 2.1.1
           - 2.2.1
           - 3.1.1
@@ -80,7 +80,7 @@ controls:
       Enable users and contributors to report defects or issues with the
       released software assets, facilitating communication and collaboration on
       defect fixes and improvements.
-    mappings:
+    guideline-mappings:
       - reference-id: BPB
         identifiers:
           - B-B-3
@@ -110,11 +110,11 @@ controls:
         identifiers:
           - 4.2.1
       - reference-id: SAMM
-        identifiers: 
+        identifiers:
           - Implementation -Defect Management -Defect Tracking Lvl1
           - Implementation -Defect Management -Defect Tracking Lvl2
       - reference-id: PCIDSS
-        identifiers: 
+        identifiers:
           - 6.3.2
           - 6.3.3
           - 6.5.1
@@ -146,7 +146,7 @@ controls:
       Enable users to verify the authenticity and integrity of the project's
       released software assets, reducing the risk of using tampered or
       unauthorized versions of the software.
-    mappings:
+    guideline-mappings:
       - reference-id: BPB
         identifiers:
           - CC-B-8
@@ -164,7 +164,7 @@ controls:
         identifiers:
           - 171-222
       - reference-id: PSSCRM
-        identifiers: 
+        identifiers:
           - G1.3
           - G2.5
           - P1.2
@@ -173,7 +173,7 @@ controls:
           - P3.3
           - E2.6
       - reference-id: PCIDSS
-        identifiers: 
+        identifiers:
           - 3.1.1
           - 3.5.1
           - 4.1.1
@@ -222,7 +222,7 @@ controls:
       Provide users with clear expectations regarding the project's support
       lifecycle. This allows downstream consumers to take relevant actions to
       ensure the continued functionality and security of their systems.
-    mappings:
+    guideline-mappings:
       - reference-id: BPB
         identifiers:
           - R-B-3
@@ -236,13 +236,13 @@ controls:
           - 4.1
           - 4.3.1
       - reference-id: PSSCRM
-        identifiers: 
-          - E1.6  
+        identifiers:
+          - E1.6
       - reference-id: SAMM
-        identifiers: 
+        identifiers:
           - Operations -Operational Management -System Decommissioning -Legacy Management Lvl1
       - reference-id: PCIDSS
-        identifiers: 
+        identifiers:
           - 2.1.1
           - 3.1.1
           - 3.2.1
@@ -278,7 +278,7 @@ controls:
       Communicating when the project maintainers will no longer fix defects or
       security vulnerabilities is crucial for downstream consumers to find
       alternative solutions or alternative means of support for the project.
-    mappings:
+    guideline-mappings:
       - reference-id: CRA
         identifiers:
           - 1.2c
@@ -292,14 +292,14 @@ controls:
           - 673-475
           - 053-751
       - reference-id: PSSCRM
-        identifiers: 
-          - E1.6  
+        identifiers:
+          - E1.6
       - reference-id: SAMM
-        identifiers: 
+        identifiers:
           - Operations -Operational Management -System Decommissioning -Legacy Management Lvl1
           - Operations -Operational Management -System Decommissioning -Legacy Management Lvl2
       - reference-id: PCIDSS
-        identifiers: 
+        identifiers:
           - 3.1.1
           - 3.2.1
           - 4.1.1
@@ -331,7 +331,7 @@ controls:
       dependencies, libraries, frameworks, etc. to help downstream consumers
       understand how the project operates in regards to third-party components
       that are required necessary for the software to function.
-    mappings:
+    guideline-mappings:
       - reference-id: BPB
         identifiers:
           - A-S-1
@@ -344,19 +344,19 @@ controls:
           - 053-751
       - reference-id: ScCrd
         identifiers:
-          - Pinned-Dependencies       
+          - Pinned-Dependencies
       - reference-id: PSSCRM
-        identifiers: 
+        identifiers:
           - G1.4
           - G2.4
           - P3.1
           - P3.2
           - P3.4
       - reference-id: SAMM
-        identifiers: 
+        identifiers:
           - Design -Security Requirements -Supplier Security Lvl2
       - reference-id: PCIDSS
-        identifiers: 
+        identifiers:
           - 2.1.1
           - 3.1.1
           - 4.1.1
@@ -366,7 +366,7 @@ controls:
           - 6.4.3
           - 7.1.1
           - 8.1.1
-          - 11.1.1 
+          - 11.1.1
           - 12.5.2
     assessment-requirements:
       - id: OSPS-DO-06.01

--- a/baseline/OSPS-GV.yaml
+++ b/baseline/OSPS-GV.yaml
@@ -15,7 +15,7 @@ controls:
       potential contributors, and downstream consumers have an accurate
       understanding of who is working on the project and what areas of authority
       they may have.
-    mappings:
+    guideline-mappings:
       - reference-id: BPB
         identifiers:
           - B-S-3
@@ -24,12 +24,12 @@ controls:
         identifiers:
           - 013-021
       - reference-id: PSSCRM
-        identifiers: 
+        identifiers:
           - G2.3
           - E3.1
           - E3.3
       - reference-id: PCIDSS
-        identifiers: 
+        identifiers:
           - 2.1.2
           - 3.1.1
           - 3.1.2
@@ -82,7 +82,7 @@ controls:
       Encourages open communication and collaboration within the project
       community, enabling users to provide feedback and discuss proposed changes
       or usage challenges.
-    mappings:
+    guideline-mappings:
       - reference-id: BPB
         identifiers:
           - B-B-3
@@ -98,7 +98,7 @@ controls:
           - PS.3
           - PW.1.2
       - reference-id: PCIDSS
-        identifiers: 
+        identifiers:
           - 12.5.2
     assessment-requirements:
       - id: OSPS-GV-02.01
@@ -122,7 +122,7 @@ controls:
       Provide guidance to new contributors on how to participate in the project,
       outlining the steps required to submit changes or enhancements to the
       project's codebase.
-    mappings:
+    guideline-mappings:
       - reference-id: BPB
         identifiers:
           - B-B-4
@@ -141,11 +141,11 @@ controls:
         identifiers:
           - 4.1.2
       - reference-id: PSSCRM
-        identifiers: 
+        identifiers:
           - G2.4
           - P2.2
       - reference-id: PCIDSS
-        identifiers: 
+        identifiers:
           - 2.1.1
           - 6.5.4
           - 8.2.1
@@ -186,7 +186,7 @@ controls:
       Ensure that code contributors are vetted and reviewed before being granted
       elevated permissions to sensitive resources within the project, reducing
       the risk of unauthorized access or misuse.
-    mappings:
+    guideline-mappings:
       - reference-id: BPB
         identifiers:
           - B-B-5
@@ -217,11 +217,11 @@ controls:
         identifiers:
           - 4.1.2
       - reference-id: PSSCRM
-        identifiers: 
+        identifiers:
           - E3.1
           - E3.3
       - reference-id: PCIDSS
-        identifiers: 
+        identifiers:
           - 2.1.1
           - 6.5.4
           - 8.2.1

--- a/baseline/OSPS-LE.yaml
+++ b/baseline/OSPS-LE.yaml
@@ -18,7 +18,7 @@ controls:
       Ensure that code contributors are aware of and acknowledge their legal
       responsibility for the contributions they make to the project, reducing
       the risk of intellectual property disputes against the project.
-    mappings:
+    guideline-mappings:
       - reference-id: BPB
         identifiers:
           - B-S-1
@@ -33,10 +33,10 @@ controls:
           - PW.1.2
           - PW.2.1
       - reference-id: PSSCRM
-        identifiers: 
-          - E3.1 
+        identifiers:
+          - E3.1
       - reference-id: PCIDSS
-        identifiers: 
+        identifiers:
           - 12.8.5
     assessment-requirements:
       - id: OSPS-LE-01.01
@@ -67,7 +67,7 @@ controls:
       Ensure that the project's source code is distributed under a recognized
       and legally enforceable open source software license, providing clarity on
       how the code can be used and shared by others.
-    mappings:
+    guideline-mappings:
       - reference-id: BPB
         identifiers:
           - B-B-6
@@ -83,12 +83,12 @@ controls:
           - GV.OC-03
       - reference-id: ScCrd
         identifiers:
-          - License          
+          - License
       - reference-id: PSSCRM
-        identifiers: 
-          - G1.2 
+        identifiers:
+          - G1.2
       - reference-id: PCIDSS
-        identifiers: 
+        identifiers:
           - 3.2.1
     assessment-requirements:
       - id: OSPS-LE-02.01
@@ -126,13 +126,13 @@ controls:
 
   - id: OSPS-LE-03
     title: |
-      All licenses for the project's source code MUST be maintained in a 
+      All licenses for the project's source code MUST be maintained in a
       standard location within the corresponding repository.
     objective: |
       Ensure that the project's source code and released software assets are
       distributed with the appropriate license terms, making it clear to users
       and contributors how each can be used and shared.
-    mappings:
+    guideline-mappings:
       - reference-id: BPB
         identifiers:
           - B-B-8
@@ -144,12 +144,12 @@ controls:
           - PO.3.2
       - reference-id: ScCrd
         identifiers:
-          - License          
+          - License
       - reference-id: PSSCRM
-        identifiers: 
-          - G1.2 
+        identifiers:
+          - G1.2
       - reference-id: PCIDSS
-        identifiers: 
+        identifiers:
           - 3.2.1
     assessment-requirements:
       - id: OSPS-LE-03.01

--- a/baseline/OSPS-QA.yaml
+++ b/baseline/OSPS-QA.yaml
@@ -16,7 +16,7 @@ controls:
     objective: |
       Enable users to access and review the project's source code and history,
       promoting transparency and collaboration within the project community.
-    mappings:
+    guideline-mappings:
       - reference-id: BPB
         identifiers:
           - CC-B-1
@@ -52,14 +52,14 @@ controls:
         identifiers:
           - Build platform - isolation strength - Isolated
       - reference-id: PSSCRM
-        identifiers: 
+        identifiers:
           - P3.5
           - E2.2
       - reference-id: SAMM
-        identifiers: 
+        identifiers:
           - Implementation -Secure Build -Build Process Lvl1
       - reference-id: PCIDSS
-        identifiers: 
+        identifiers:
           - 2.1.1
           - 6.2.1
           - 6.5.1
@@ -100,7 +100,7 @@ controls:
       Provide transparency and accountability for the project's dependencies
       while enabling users and contributors to understand the software's direct
       dependencies.
-    mappings:
+    guideline-mappings:
       - reference-id: BPB
         identifiers:
           - Q-S-8
@@ -133,7 +133,7 @@ controls:
           - 863-521
           - 613-286
       - reference-id: PSSCRM
-        identifiers: 
+        identifiers:
           - G1.4
           - G1.5
           - G2.5
@@ -144,10 +144,10 @@ controls:
           - E2.1
           - E2.2
       - reference-id: SAMM
-        identifiers: 
+        identifiers:
           - Implementation -Secure Build -Software Dependencies Lvl1
       - reference-id: PCIDSS
-        identifiers: 
+        identifiers:
           - 6.3.2
           - 6.4.3
           - 12.5.1
@@ -186,7 +186,7 @@ controls:
       failing status checks, even if arbitrary, because it increases the risk of
       overlooking security vulnerabilities or defects identified by automated
       checks.
-    mappings:
+    guideline-mappings:
       - reference-id: CRA
         identifiers:
           - 1.2f
@@ -208,7 +208,7 @@ controls:
           - 263-184
           - 253-452
       - reference-id: PSSCRM
-        identifiers: 
+        identifiers:
           - G2.2
           - G5.3
           - G5.4
@@ -216,14 +216,14 @@ controls:
           - P4.1
           - P4.2
       - reference-id: SAMM
-        identifiers: 
+        identifiers:
           - Implementation -Secure Build -Build Process Lvl3
           - Implementation -Secure Build -Software Dependencies Lvl3
           - Verification -Requirements Testing -Control Verification Lvl1
           - Verification -Requirements Testing -Control Verification Lvl2
           - Verification -Requirements Testing -Control Verification Lvl3
       - reference-id: PCIDSS
-        identifiers: 
+        identifiers:
           - 6.3.1
           - 6.3.2
           - 6.5.2
@@ -251,7 +251,7 @@ controls:
       Ensure that additional code repositories or subprojects produced by the
       project are held to a standard that is clear and appropriate for that
       codebase.
-    mappings:
+    guideline-mappings:
       - reference-id: CRA
         identifiers:
           - 1.2b
@@ -272,13 +272,13 @@ controls:
           - Build platform - isolation strength - Isolated
       - reference-id: ScCrd
         identifiers:
-          - Binary-Artifacts          
+          - Binary-Artifacts
       - reference-id: PSSCRM
-        identifiers: 
+        identifiers:
           - G2.2
-          - G5.4   
+          - G5.4
       - reference-id: PCIDSS
-        identifiers: 
+        identifiers:
           - 6.4.2
     assessment-requirements:
       - id: OSPS-QA-04.01
@@ -317,7 +317,7 @@ controls:
       Reduce the risk of including generated executable artifacts in the
       project's version control system, ensuring that only source code and
       necessary files are stored in the repository.
-    mappings:
+    guideline-mappings:
       - reference-id: CRA
         identifiers:
           - 1.2b
@@ -330,7 +330,7 @@ controls:
           - 486-813
           - 124-564
       - reference-id: PCIDSS
-        identifiers: 
+        identifiers:
           - 6.4.3
     assessment-requirements:
       - id: OSPS-QA-05.01
@@ -369,7 +369,7 @@ controls:
     objective: |
       Ensure that the project uses at least one automated test suite for the
       source code repository and clearly documents when and how tests are run.
-    mappings:
+    guideline-mappings:
       - reference-id: BPB
         identifiers:
           - Q-B-4
@@ -395,9 +395,9 @@ controls:
           - 088-377
       - reference-id: ScCrd
         identifiers:
-          - CI-Tests          
+          - CI-Tests
       - reference-id: PSSCRM
-        identifiers: 
+        identifiers:
           - P4.1
           - P4.2
           - P4.3
@@ -405,13 +405,13 @@ controls:
           - E2.4
           - E2.5
       - reference-id: SAMM
-        identifiers: 
+        identifiers:
           - Verification-Requirements -Testing -Control Verification Lvl1
-          - Verification-Requirements -Testing -Control Verification Lvl2 
-          - Verification-Requirements -Testing -Control Verification Lvl3 
+          - Verification-Requirements -Testing -Control Verification Lvl2
+          - Verification-Requirements -Testing -Control Verification Lvl3
           - Verification -Security Testing -Scalable Baseline Lvl3
       - reference-id: PCIDSS
-        identifiers: 
+        identifiers:
           - 6.2.3
           - 6.3.1
           - 6.3.2
@@ -464,20 +464,20 @@ controls:
       Ensure that the project's version control system requires at least one
       non-author approval of changes before merging into the release or primary
       branch.
-    mappings:
+    guideline-mappings:
       - reference-id: BPB
         identifiers:
           - B-G-3
       - reference-id: ScCrd
         identifiers:
-          - Code-Review          
+          - Code-Review
       - reference-id: PSSCRM
-        identifiers: 
+        identifiers:
           - G2.4
           - P3.3
           - P3.5
       - reference-id: PCIDSS
-        identifiers: 
+        identifiers:
           - 6.2.3.1
           - 6.4.2
           - 6.5.4

--- a/baseline/OSPS-SA.yaml
+++ b/baseline/OSPS-SA.yaml
@@ -14,7 +14,7 @@ controls:
       the interactions and components of the system to help contributors and
       security reviewers understand the internal logic of the released software
       assets.
-    mappings:
+    guideline-mappings:
       - reference-id: BPB
         identifiers:
           - B-B-1
@@ -40,16 +40,16 @@ controls:
           - 036-275
           - 162-655
       - reference-id: PSSCRM
-        identifiers: 
+        identifiers:
           - G5.1
           - P1.1
           - E3.4
           - E3.7
       - reference-id: SAMM
-        identifiers: 
+        identifiers:
           - Operations -Operational Management -Data Protection Lvl2
       - reference-id: PCIDSS
-        identifiers: 
+        identifiers:
           - 2.2.1
           - 2.2.3
           - 2.2.4
@@ -89,7 +89,7 @@ controls:
       Provide users and developers with an understanding of how to interact with
       the project's software and integrate it with other systems, enabling them
       to use the software effectively.
-    mappings:
+    guideline-mappings:
       - reference-id: BPB
         identifiers:
           - B-B-10
@@ -115,11 +115,11 @@ controls:
           - 072-713
           - 820-878
       - reference-id: PSSCRM
-        identifiers: 
+        identifiers:
           - E3.4
-          - E3.7  
+          - E3.7
       - reference-id: PCIDSS
-        identifiers: 
+        identifiers:
           - 2.2.1
           - 2.2.3
           - 2.2.4
@@ -150,7 +150,7 @@ controls:
       Provide project maintainers an understanding of how the software can be
       misused or broken allows them to plan mitigations to close off the potential
       of those threats from occurring.
-    mappings:
+    guideline-mappings:
       - reference-id: BPB
         identifiers:
           - B-S-8
@@ -180,18 +180,18 @@ controls:
           - 154-031
           - 888-770
       - reference-id: PSSCRM
-        identifiers: 
+        identifiers:
           - G4.3
           - G5.2
           - P2.1
       - reference-id: SAMM
-        identifiers: 
-          - Governance -Create and Promote Lvl1  
-          - Design -Threat Assessment -Application Risk Profile Lvl1  
-          - Design -Threat Assessment -Threat Modeling Lvl1 
+        identifiers:
+          - Governance -Create and Promote Lvl1
+          - Design -Threat Assessment -Application Risk Profile Lvl1
+          - Design -Threat Assessment -Threat Modeling Lvl1
           - Verification -Architecture Assessment -Architecture Mitigation Lvl2
       - reference-id: PCIDSS
-        identifiers: 
+        identifiers:
           - 2.2.4
           - 2.2.5
           - 2.2.6
@@ -227,7 +227,7 @@ controls:
         applicability:
           - Maturity Level 3
         recommendation: |
-          Threat modeling is an activity where the project looks at the 
+          Threat modeling is an activity where the project looks at the
           codebase, associated processes and infrastructure, interfaces, key
           components and "thinks like a hacker" and brainstorms how the system
           be be broken or compromised. Each identified threat is listed out so

--- a/baseline/OSPS-VM.yaml
+++ b/baseline/OSPS-VM.yaml
@@ -13,9 +13,9 @@ controls:
         vulnerability disclosure, with a clear timeframe for response.
     objective: |
       Establish a process for reporting and addressing vulnerabilities in the
-      project, ensuring that security issues are handled promptly and 
+      project, ensuring that security issues are handled promptly and
       transparently.
-    mappings:
+    guideline-mappings:
       - reference-id: BPB
         identifiers:
           - R-B-6
@@ -50,17 +50,17 @@ controls:
           - 887-750
       - reference-id: ScCrd
         identifiers:
-          - Security-Policy          
+          - Security-Policy
       - reference-id: PSSCRM
-        identifiers: 
+        identifiers:
           - D1.1
           - D1.2
           - D1.3
           - D1.5
       - reference-id: SAMM
-        identifiers: 
-          - Governance -Create and Promote Lvl2  
-          - Governance -Policy & Compliance -Policy & Standards Lvl1  
+        identifiers:
+          - Governance -Create and Promote Lvl2
+          - Governance -Policy & Compliance -Policy & Standards Lvl1
           - Implementation -Defect Management -Defect Tracking Lvl1
           - Implementation -Defect Management -Defect Tracking Lvl2
           - Implementation -Defect Management -Defect Tracking Lvl3
@@ -68,7 +68,7 @@ controls:
           - Operations -Incident Management -Incident Response Lvl2
           - Operations -Incident Management -Incident Response Lvl3
       - reference-id: PCIDSS
-        identifiers: 
+        identifiers:
           - 2.1.1
           - 3.1.1
           - 4.1.1
@@ -106,7 +106,7 @@ controls:
       vulnerabilities in a project. People with vulnerabilities to report should
       have a clear understanding of the process so that they can quickly submit
       the report to the project.
-    mappings:
+    guideline-mappings:
       - reference-id: BPB
         identifiers:
           - B-S-8
@@ -132,12 +132,12 @@ controls:
           - 464-513
       - reference-id: ScCrd
         identifiers:
-          - Security-Policy                  
+          - Security-Policy
       - reference-id: SAMM
-        identifiers: 
-          - Governance -Policy&Compliance -Policy&Standards Lvl2 
+        identifiers:
+          - Governance -Policy&Compliance -Policy&Standards Lvl2
       - reference-id: PCIDSS
-        identifiers: 
+        identifiers:
           - 6.3.3
           - 12.1.1
           - 12.10.2
@@ -158,9 +158,9 @@ controls:
       vulnerabilities privately to the security contacts within the project.
     objective: |
       Security vulnerabilities should not be shared with the public until such
-      time the project has been provided time to analyze and prepare 
+      time the project has been provided time to analyze and prepare
       remediations to protect users of the project.
-    mappings:
+    guideline-mappings:
       - reference-id: BPB
         identifiers:
           - R-B-7
@@ -172,10 +172,10 @@ controls:
         identifiers:
           - 308-514
       - reference-id: SAMM
-        identifiers: 
-          - Operations -Incident Management -Incident Response Lvl3 
+        identifiers:
+          - Operations -Incident Management -Incident Response Lvl3
       - reference-id: PCIDSS
-        identifiers: 
+        identifiers:
           - 6.3.1
           - 6.3.3
           - 12.10.2
@@ -200,7 +200,7 @@ controls:
     objective: |
       Consumers of the project must be informed about known vulnerabilities
       found within the project.
-    mappings:
+    guideline-mappings:
       - reference-id: CRA
         identifiers:
           - 1.2a
@@ -220,11 +220,11 @@ controls:
         identifiers:
           - 4.1.5
       - reference-id: PSSCRM
-        identifiers: 
+        identifiers:
           - G2.2
           - D1.1
       - reference-id: PCIDSS
-        identifiers: 
+        identifiers:
           - 6.2.3
           - 6.3.1
           - 6.3.2
@@ -253,7 +253,7 @@ controls:
         applicability:
           - Maturity Level 3
         recommendation: |
-          Establish a VEX feed communicating the exploitability status of 
+          Establish a VEX feed communicating the exploitability status of
           known vulnerabilities, including assessment details or any
           mitigations in place preventing vulnerable code from being
           executed.
@@ -269,7 +269,7 @@ controls:
       is merged as well as before it releases, reducing the risk of compromised
       delivery mechanisms or released software assets that are vulnerable or
       malicious.
-    mappings:
+    guideline-mappings:
       - reference-id: BPB
         identifiers:
           - B-S-8
@@ -325,10 +325,10 @@ controls:
           - 088-377
       - reference-id: ScCrd
         identifiers:
-          - Security-Policy  
+          - Security-Policy
           - Vulnerabilities
       - reference-id: PSSCRM
-        identifiers: 
+        identifiers:
           - G5.4
           - P4.1
           - P4.2
@@ -336,13 +336,13 @@ controls:
           - P4.4
           - P4.5
       - reference-id: SAMM
-        identifiers: 
+        identifiers:
           - Implementation -Secure Build-Build Process Lvl3
           - Implementation -Software Dependencies Lvl3
           - Verification -Security Testing -Scalable Baseline Lvl1
-          - Verification -Security Testing -Scalable Baseline Lvl3 
+          - Verification -Security Testing -Scalable Baseline Lvl3
       - reference-id: PCIDSS
-        identifiers: 
+        identifiers:
           - 6.2.3
           - 6.3.1
           - 6.3.2
@@ -394,7 +394,7 @@ controls:
       Identify and address defects and security weaknesses in the project's
       codebase early in the development process, reducing the risk of shipping
       insecure software.
-    mappings: 
+    guideline-mappings:
       - reference-id: BPB
         identifiers:
           - B-S-8
@@ -450,11 +450,11 @@ controls:
           - 088-377
       - reference-id: ScCrd
         identifiers:
-          - Security-Policy  
+          - Security-Policy
           - Vulnerabilities
           - SAST
       - reference-id: PSSCRM
-        identifiers: 
+        identifiers:
           - G5.4
           - P4.1
           - P4.2
@@ -462,13 +462,13 @@ controls:
           - P4.4
           - P4.5
       - reference-id: SAMM
-        identifiers: 
+        identifiers:
           - Implementation -Secure Build-Build Process Lvl3
           - Implementation -Software Dependencies Lvl3
           - Verification -Security Testing -Scalable Baseline Lvl1
-          - Verification -Security Testing -Scalable Baseline Lvl3 
+          - Verification -Security Testing -Scalable Baseline Lvl3
       - reference-id: PCIDSS
-        identifiers: 
+        identifiers:
           - 6.2.3
           - 6.3.1
           - 6.3.2

--- a/cmd/pkg/baseline/loader.go
+++ b/cmd/pkg/baseline/loader.go
@@ -106,7 +106,7 @@ func (l *Loader) loadControlFamily(familyID string) (*layer2.ControlFamily, erro
 
 	controlFamily := &layer2.ControlFamily{}
 
-	decoder := yaml.NewDecoder(file)
+	decoder := yaml.NewDecoder(file, yaml.Strict())
 	if err := decoder.Decode(controlFamily); err != nil {
 		return nil, fmt.Errorf("error decoding %s YAML: %w", familyID, err)
 	}

--- a/cmd/template.md
+++ b/cmd/template.md
@@ -106,6 +106,7 @@ For more information on the project and to make contributions, visit the [GitHub
 
 **Recommendation:** {{ .Recommendation }}
 
+**Control applies to:**
 {{ range .Applicability }}- {{ . }}
 {{ end }}
 
@@ -114,8 +115,8 @@ For more information on the project and to make contributions, visit the [GitHub
 #### External Framework Mappings
 {{ if  .GuidelineMappings }}
   {{ range .GuidelineMappings }}
-  - **{{ .ReferenceID | addLinks }}**: {{ range $index, $id := .Identifiers }}{{ if $index }}, {{ end }}{{ $id }}{{ end }}
-  {{ end }}
+  - **{{ .ReferenceId | addLinks }}**: {{ range $index, $id := .Identifiers }}{{ if $index }}, {{ end }}{{ $id }}{{ end }}
+  {{- end }}
 {{ end }}
 
 ---


### PR DESCRIPTION
Visiting https://baseline.openssf.org/versions/devel#osps-ac-0101 shows that the content under the heading `External Framework Mappings` is missing from the control content in the page.

This change adjusts the field naming of the baseline controls in the data files to match the expected name of `guideline-mappings` and adjusts the template file slightly to match the expected sci/layer2 types and fields available for templating.

This is a defect that should have been caught by our CI process, but was not due to the lack of strict unmarshaling configuration in `loadControlFamily`. This change adds that configuration which results in the following failure against the `main` branch when running `cd cmd && go run . compile --output foo.md`:

```
ERROR: loading control family AC: error decoding AC YAML: [19:5] unknown field "mappings"
  16 |       Reduce the risk of account compromise or insider threats by requiring
  17 |       multi-factor authentication for collaborators modifying the project
  18 |       repository settings or accessing sensitive data.
> 19 |     mappings:
           ^
  20 |       - reference-id: BPB
  21 |         identifiers:
  22 |           - CC-G-1
  23 |       
exit status 1
```