### PR TITLE
Fix a rendering bug caused by missing whitespace

### DIFF
--- a/cmd/template.md
+++ b/cmd/template.md
@@ -149,7 +149,7 @@ Controls within this document may map to the following external frameworks:
   - {{.}}
 {{ end -}}
 {{ end -}}
-{{ end -}}
+{{ end }}
 
 ---
 


### PR DESCRIPTION
Jekyll uses `{{ end -}}` to mean "ignore the following whitespace", which can cause problems when a for loop is followed by `----`. But it renders correctly now!

Fixes #320 