### PR TITLE
Renamed some framework IDs (non-functional)

### DIFF
--- a/.project-words.txt
+++ b/.project-words.txt
@@ -15,7 +15,7 @@ lifecycles
 NCSC
 openssf
 organisations
-OCRE
+OpenCRE
 OSCAL
 OSPS
 PCIDSS

--- a/baseline/OSPS-AC.yaml
+++ b/baseline/OSPS-AC.yaml
@@ -34,7 +34,7 @@ controls:
         identifiers:
           - PR.A-02
           - PR.A-05
-      - reference-id: OCRE
+      - reference-id: OpenCRE
         identifiers:
           - 486-813
           - 124-564
@@ -98,7 +98,7 @@ controls:
         identifiers:
           - PR.AA-02
           - PR.AA-05
-      - reference-id: OCRE
+      - reference-id: OpenCRE
         identifiers:
           - 486-813
           - 124-564
@@ -152,12 +152,12 @@ controls:
         identifiers:
           - PR.A-02
           - PR.A-05
-      - reference-id: OCRE
+      - reference-id: OpenCRE
         identifiers:
           - 486-813
           - 124-564
           - 152-725
-      - reference-id: ScCrd
+      - reference-id: Scorecard
         identifiers:
           - Branch-Protection
       - reference-id: PSSCRM
@@ -225,7 +225,7 @@ controls:
         identifiers:
           - PR.AA-02
           - PR.AA-05
-      - reference-id: OCRE
+      - reference-id: OpenCRE
         identifiers:
           - 486-813
           - 124-564

--- a/baseline/OSPS-BR.yaml
+++ b/baseline/OSPS-BR.yaml
@@ -29,7 +29,7 @@ controls:
       - reference-id: CSF
         identifiers:
           - PR.AA-02
-      - reference-id: OCRE
+      - reference-id: OpenCRE
         identifiers:
           - 486-813
           - 124-564
@@ -93,7 +93,7 @@ controls:
           - PS.1
           - PS.2
           - PS.3
-      - reference-id: OCRE
+      - reference-id: OpenCRE
         identifiers:
           - 486-813
           - 124-564
@@ -161,7 +161,7 @@ controls:
           - PO.5.2
           - PS.1
           - PS.2
-      - reference-id: OCRE
+      - reference-id: OpenCRE
         identifiers:
           - 483-813
           - 124-564
@@ -243,7 +243,7 @@ controls:
           - PS.2
           - PS.3
           - PW.1.2
-      - reference-id: OCRE
+      - reference-id: OpenCRE
         identifiers:
           - 483-813
           - 068-486
@@ -322,7 +322,7 @@ controls:
           - PO.3.2
           - PS.1
           - PS.2
-      - reference-id: OCRE
+      - reference-id: OpenCRE
         identifiers:
           - 486-813
           - 124-564
@@ -377,7 +377,7 @@ controls:
           - PS.2
           - PS.2.1
           - PW.6.2
-      - reference-id: ScCrd
+      - reference-id: Scorecard
         identifiers:
           - Signed-Releases
       - reference-id: SLSA

--- a/baseline/OSPS-DO.yaml
+++ b/baseline/OSPS-DO.yaml
@@ -35,10 +35,10 @@ controls:
         identifiers:
           - GV.OC-04
           - GV.OC-05
-      - reference-id: OC
+      - reference-id: "18974"
         identifiers:
           - 4.1.4
-      - reference-id: OCRE
+      - reference-id: OpenCRE
         identifiers:
           - 036-275
       - reference-id: PSSCRM
@@ -109,7 +109,7 @@ controls:
         identifiers:
           - RS.MA-02
           - GV.RM-05
-      - reference-id: OC
+      - reference-id: "18974"
         identifiers:
           - 4.2.1
       - reference-id: SAMM
@@ -167,7 +167,7 @@ controls:
           - PS.2.1
           - PS.3.1
           - RV.1.3
-      - reference-id: OCRE
+      - reference-id: OpenCRE
         identifiers:
           - 171-222
       - reference-id: PSSCRM
@@ -241,7 +241,7 @@ controls:
           - PO.4.2
           - PS.3.1
           - RV.1.3
-      - reference-id: OC
+      - reference-id: "18974"
         identifiers:
           - 4.1
           - 4.3.1
@@ -297,11 +297,11 @@ controls:
         identifiers:
           - 1.2c
           - 2.6
-      - reference-id: OC
+      - reference-id: "18974"
         identifiers:
           - 4.1.1
           - 4.3.1
-      - reference-id: OCRE
+      - reference-id: OpenCRE
         identifiers:
           - 673-475
           - 053-751
@@ -356,11 +356,11 @@ controls:
       - reference-id: CRA
         identifiers:
           - 2.1
-      - reference-id: OCRE
+      - reference-id: OpenCRE
         identifiers:
           - 613-286
           - 053-751
-      - reference-id: ScCrd
+      - reference-id: Scorecard
         identifiers:
           - Pinned-Dependencies
       - reference-id: PSSCRM

--- a/baseline/OSPS-DO.yaml
+++ b/baseline/OSPS-DO.yaml
@@ -35,7 +35,7 @@ controls:
         identifiers:
           - GV.OC-04
           - GV.OC-05
-      - reference-id: "18974"
+      - reference-id: ISO-18974
         identifiers:
           - 4.1.4
       - reference-id: OpenCRE
@@ -109,7 +109,7 @@ controls:
         identifiers:
           - RS.MA-02
           - GV.RM-05
-      - reference-id: "18974"
+      - reference-id: ISO-18974
         identifiers:
           - 4.2.1
       - reference-id: SAMM
@@ -241,7 +241,7 @@ controls:
           - PO.4.2
           - PS.3.1
           - RV.1.3
-      - reference-id: "18974"
+      - reference-id: ISO-18974
         identifiers:
           - 4.1
           - 4.3.1
@@ -297,7 +297,7 @@ controls:
         identifiers:
           - 1.2c
           - 2.6
-      - reference-id: "18974"
+      - reference-id: ISO-18974
         identifiers:
           - 4.1.1
           - 4.3.1

--- a/baseline/OSPS-GV.yaml
+++ b/baseline/OSPS-GV.yaml
@@ -137,7 +137,7 @@ controls:
       - reference-id: SSDF
         identifiers:
           - PW.1.2
-      - reference-id: "18974"
+      - reference-id: ISO-18974
         identifiers:
           - 4.1.2
       - reference-id: PSSCRM
@@ -213,7 +213,7 @@ controls:
         identifiers:
           - 123-124
           - 152-725
-      - reference-id: "18974"
+      - reference-id: ISO-18974
         identifiers:
           - 4.1.2
       - reference-id: PSSCRM

--- a/baseline/OSPS-GV.yaml
+++ b/baseline/OSPS-GV.yaml
@@ -20,7 +20,7 @@ controls:
         identifiers:
           - B-S-3
           - B-S-4
-      - reference-id: OCRE
+      - reference-id: OpenCRE
         identifiers:
           - 013-021
       - reference-id: PSSCRM
@@ -137,7 +137,7 @@ controls:
       - reference-id: SSDF
         identifiers:
           - PW.1.2
-      - reference-id: OC
+      - reference-id: "18974"
         identifiers:
           - 4.1.2
       - reference-id: PSSCRM
@@ -209,11 +209,11 @@ controls:
         identifiers:
           - PR.AA-02
           - PR.AA-05
-      - reference-id: OCRE
+      - reference-id: OpenCRE
         identifiers:
           - 123-124
           - 152-725
-      - reference-id: OC
+      - reference-id: "18974"
         identifiers:
           - 4.1.2
       - reference-id: PSSCRM

--- a/baseline/OSPS-LE.yaml
+++ b/baseline/OSPS-LE.yaml
@@ -81,7 +81,7 @@ controls:
       - reference-id: CSF
         identifiers:
           - GV.OC-03
-      - reference-id: ScCrd
+      - reference-id: Scorecard
         identifiers:
           - License
       - reference-id: PSSCRM
@@ -142,7 +142,7 @@ controls:
       - reference-id: SSDF
         identifiers:
           - PO.3.2
-      - reference-id: ScCrd
+      - reference-id: Scorecard
         identifiers:
           - License
       - reference-id: PSSCRM

--- a/baseline/OSPS-QA.yaml
+++ b/baseline/OSPS-QA.yaml
@@ -45,7 +45,7 @@ controls:
           - ID.AM-02
           - ID.RA-01
           - ID.RA-08
-      - reference-id: "18974"
+      - reference-id: ISO-18974
         identifiers:
           - 4.1.4
       - reference-id: SLSA
@@ -121,7 +121,7 @@ controls:
         identifiers:
           - ID.AM.01
           - ID.AM-02
-      - reference-id: "18974"
+      - reference-id: ISO-18974
         identifiers:
           - 4.1.5
           - 4.3.1
@@ -203,7 +203,7 @@ controls:
       - reference-id: CSF
         identifiers:
           - ID.IM-02
-      - reference-id: "18974"
+      - reference-id: ISO-18974
         identifiers:
           - 4.1.5
       - reference-id: OpenCRE
@@ -389,7 +389,7 @@ controls:
       - reference-id: CSF
         identifiers:
           - ID.AM-02
-      - reference-id: "18974"
+      - reference-id: ISO-18974
         identifiers:
           - 4.1.5
       - reference-id: OpenCRE

--- a/baseline/OSPS-QA.yaml
+++ b/baseline/OSPS-QA.yaml
@@ -35,7 +35,7 @@ controls:
           - PS.3
           - PW.1.2
           - PW.2.1
-      - reference-id: OCRE
+      - reference-id: OpenCRE
         identifiers:
           - 486-813
           - 124-564
@@ -45,7 +45,7 @@ controls:
           - ID.AM-02
           - ID.RA-01
           - ID.RA-08
-      - reference-id: OC
+      - reference-id: "18974"
         identifiers:
           - 4.1.4
       - reference-id: SLSA
@@ -121,11 +121,11 @@ controls:
         identifiers:
           - ID.AM.01
           - ID.AM-02
-      - reference-id: OC
+      - reference-id: "18974"
         identifiers:
           - 4.1.5
           - 4.3.1
-      - reference-id: OCRE
+      - reference-id: OpenCRE
         identifiers:
           - 486-813
           - 124-564
@@ -203,10 +203,10 @@ controls:
       - reference-id: CSF
         identifiers:
           - ID.IM-02
-      - reference-id: OC
+      - reference-id: "18974"
         identifiers:
           - 4.1.5
-      - reference-id: OCRE
+      - reference-id: OpenCRE
         identifiers:
           - 263-184
           - 253-452
@@ -266,14 +266,14 @@ controls:
           - PS.1
           - PS.2
           - RV.1.2
-      - reference-id: OCRE
+      - reference-id: OpenCRE
         identifiers:
           - 486-813
           - 124-564
       - reference-id: SLSA
         identifiers:
           - Build platform - isolation strength - Isolated
-      - reference-id: ScCrd
+      - reference-id: Scorecard
         identifiers:
           - Binary-Artifacts
       - reference-id: PSSCRM
@@ -328,7 +328,7 @@ controls:
         identifiers:
           - PS.1
           - PS.2
-      - reference-id: OCRE
+      - reference-id: OpenCRE
         identifiers:
           - 486-813
           - 124-564
@@ -389,14 +389,14 @@ controls:
       - reference-id: CSF
         identifiers:
           - ID.AM-02
-      - reference-id: OC
+      - reference-id: "18974"
         identifiers:
           - 4.1.5
-      - reference-id: OCRE
+      - reference-id: OpenCRE
         identifiers:
           - 207-435
           - 088-377
-      - reference-id: ScCrd
+      - reference-id: Scorecard
         identifiers:
           - CI-Tests
       - reference-id: PSSCRM
@@ -471,7 +471,7 @@ controls:
       - reference-id: BPB
         identifiers:
           - B-G-3
-      - reference-id: ScCrd
+      - reference-id: Scorecard
         identifiers:
           - Code-Review
       - reference-id: PSSCRM

--- a/baseline/OSPS-SA.yaml
+++ b/baseline/OSPS-SA.yaml
@@ -108,7 +108,7 @@ controls:
         identifiers:
           - GV.OC-05
           - ID.AM-01
-      - reference-id: "18974"
+      - reference-id: ISO-18974
         identifiers:
           - 4.1.4
       - reference-id: OpenCRE
@@ -174,7 +174,7 @@ controls:
           - ID.RA-04
           - ID.RA-05
           - DE.AE-07
-      - reference-id: "18974"
+      - reference-id: ISO-18974
         identifiers:
           - 4.1.5
       - reference-id: OpenCRE

--- a/baseline/OSPS-SA.yaml
+++ b/baseline/OSPS-SA.yaml
@@ -32,7 +32,7 @@ controls:
       - reference-id: CSF
         identifiers:
           - ID.AM-02
-      - reference-id: OCRE
+      - reference-id: OpenCRE
         identifiers:
           - 155-155
           - 326-704
@@ -108,10 +108,10 @@ controls:
         identifiers:
           - GV.OC-05
           - ID.AM-01
-      - reference-id: OC
+      - reference-id: "18974"
         identifiers:
           - 4.1.4
-      - reference-id: OCRE
+      - reference-id: OpenCRE
         identifiers:
           - 155-155
           - 068-102
@@ -174,10 +174,10 @@ controls:
           - ID.RA-04
           - ID.RA-05
           - DE.AE-07
-      - reference-id: OC
+      - reference-id: "18974"
         identifiers:
           - 4.1.5
-      - reference-id: OCRE
+      - reference-id: OpenCRE
         identifiers:
           - 068-102
           - 154-031

--- a/baseline/OSPS-VM.yaml
+++ b/baseline/OSPS-VM.yaml
@@ -40,7 +40,7 @@ controls:
           - GV.PO-02
           - ID.RA-01
           - ID.RA-08
-      - reference-id: "18974"
+      - reference-id: ISO-18974
         identifiers:
           - 4.1.5
           - 4.2.1
@@ -126,7 +126,7 @@ controls:
           - GV.PO-01
           - GV.PO-02
           - ID.RA-01
-      - reference-id: "18974"
+      - reference-id: ISO-18974
         identifiers:
           - 4.1.1
           - 4.1.3
@@ -227,7 +227,7 @@ controls:
       - reference-id: CSF
         identifiers:
           - ID.RA-01
-      - reference-id: "18974"
+      - reference-id: ISO-18974
         identifiers:
           - 4.1.5
       - reference-id: PSSCRM
@@ -324,7 +324,7 @@ controls:
           - ID.RA-01
           - ID.RA-08
           - ID.IM-02
-      - reference-id: "18974"
+      - reference-id: ISO-18974
         identifiers:
           - 4.1.5
           - 4.2.1
@@ -453,7 +453,7 @@ controls:
           - ID.RA-01
           - ID.RA-08
           - ID.IM-02
-      - reference-id: "18974"
+      - reference-id: ISO-18974
         identifiers:
           - 4.1.5
           - 4.2.1

--- a/baseline/OSPS-VM.yaml
+++ b/baseline/OSPS-VM.yaml
@@ -40,15 +40,15 @@ controls:
           - GV.PO-02
           - ID.RA-01
           - ID.RA-08
-      - reference-id: OC
+      - reference-id: "18974"
         identifiers:
           - 4.1.5
           - 4.2.1
           - 4.3.2
-      - reference-id: OCRE
+      - reference-id: OpenCRE
         identifiers:
           - 887-750
-      - reference-id: ScCrd
+      - reference-id: Scorecard
         identifiers:
           - Security-Policy
       - reference-id: PSSCRM
@@ -126,16 +126,16 @@ controls:
           - GV.PO-01
           - GV.PO-02
           - ID.RA-01
-      - reference-id: OC
+      - reference-id: "18974"
         identifiers:
           - 4.1.1
           - 4.1.3
           - 4.1.5
           - 4.2.2
-      - reference-id: OCRE
+      - reference-id: OpenCRE
         identifiers:
           - 464-513
-      - reference-id: ScCrd
+      - reference-id: Scorecard
         identifiers:
           - Security-Policy
       - reference-id: SAMM
@@ -176,7 +176,7 @@ controls:
         identifiers:
           - 2.5
           - 2.6
-      - reference-id: OCRE
+      - reference-id: OpenCRE
         identifiers:
           - 308-514
       - reference-id: SAMM
@@ -227,7 +227,7 @@ controls:
       - reference-id: CSF
         identifiers:
           - ID.RA-01
-      - reference-id: OC
+      - reference-id: "18974"
         identifiers:
           - 4.1.5
       - reference-id: PSSCRM
@@ -324,13 +324,13 @@ controls:
           - ID.RA-01
           - ID.RA-08
           - ID.IM-02
-      - reference-id: OC
+      - reference-id: "18974"
         identifiers:
           - 4.1.5
           - 4.2.1
           - 4.2.2
           - 4.3.2
-      - reference-id: OCRE
+      - reference-id: OpenCRE
         identifiers:
           - 155-155
           - 124-564
@@ -339,7 +339,7 @@ controls:
           - 611-158
           - 207-435
           - 088-377
-      - reference-id: ScCrd
+      - reference-id: Scorecard
         identifiers:
           - Security-Policy
           - Vulnerabilities
@@ -453,13 +453,13 @@ controls:
           - ID.RA-01
           - ID.RA-08
           - ID.IM-02
-      - reference-id: OC
+      - reference-id: "18974"
         identifiers:
           - 4.1.5
           - 4.2.1
           - 4.2.2
           - 4.3.2
-      - reference-id: OCRE
+      - reference-id: OpenCRE
         identifiers:
           - 155-155
           - 124-564
@@ -468,7 +468,7 @@ controls:
           - 611-158
           - 207-435
           - 088-377
-      - reference-id: ScCrd
+      - reference-id: Scorecard
         identifiers:
           - Security-Policy
           - Vulnerabilities

--- a/baseline/lexicon.yaml
+++ b/baseline/lexicon.yaml
@@ -235,7 +235,7 @@
   definition: |
     A Linux Foundation project that oversee two ISO/IEC standards to better understand and manage software supply chains. 
   synonyms: 
-    - OC 
+    - "18974" 
     - ISO/IEC 5230
     - ISO/IEC 18974
   references: 
@@ -245,7 +245,7 @@
   definition: |
      An OWASP project that converts cybersecurity requirements into a hierarchical, machine-readable format.
   synonyms: 
-    - OCRE 
+    - OpenCRE 
   references: 
     - https://www.opencre.org/
     - https://zeljkoobrenovic.github.io/opencre-explorer/ 

--- a/baseline/metadata.yaml
+++ b/baseline/metadata.yaml
@@ -1,0 +1,173 @@
+id: osps-baseline
+title: Open Source Project Security Baseline
+version: ""
+description: |
+  The Open Source Project Security (OSPS) Baseline is a set of security criteria
+  that projects should meet to demonstrate a strong security posture.
+last-modified: "" 
+
+applicability-categories: #TODO: Update all applicability levels to use these IDs in a follow-up PR
+  - id: maturity-1
+    title: Maturity Level 1
+    description: for any code or non-code project with any number of maintainers or users
+  - id: maturity-2
+    title: Maturity Level 2
+    description: for any code project that has at least 2 maintainers and a small number of consistent users
+  - id: maturity-3
+    title: Maturity Level 3
+    description: for any code project that has a large number of consistent users
+
+mapping-references:
+  - id: BPB
+    title: OpenSSF Best Practices Badge
+    version: ""
+    url: https://github.com/coreinfrastructure/best-practices-badge/blob/main/criteria/criteria.yml
+    description: |
+      The Open Source Security Foundation (OpenSSF) Best Practices Badge is a way 
+      for Free/Libre and Open Source Software (FLOSS) projects to show that they
+      follow best practices. Projects can voluntarily self-certify, at no cost,
+      by using this web application to explain how they follow each best practice.
+      The OpenSSF Best Practices Badge is inspired by the many badges available
+      to projects on GitHub. Consumers of the badge can quickly assess which
+      FLOSS projects are following best practices and, as a result, are more
+      likely to produce higher-quality secure software.
+  - id: CRA
+    title: Cyber Resilience Act (Regulation 2024/2847)
+    version: "20.11.2024"
+    url: https://eur-lex.europa.eu/legal-content/EN/TXT/HTML/?uri=OJ:L_202402847
+    description: |
+      Regulation (EU) 2024/2847 of the European Parliament and of the
+      Council of 23 October 2024 on horizontal cybersecurity requirements for
+      products with digital elements and amending Regulations (EU) No 168/2013 and
+      (EU) 2019/1020 and Directive (EU) 2020/1828 (Cyber Resilience Act) (Text with
+      EEA relevance)
+  - id: CSF
+    title: NIST Cybersecurity Framework
+    version: "2.0"
+    url: https://nvlpubs.nist.gov/nistpubs/CSWP/NIST.CSWP.29.pdf
+    description: |
+      The NIST Cybersecurity Framework (CSF) 2.0 provides guidance to industry,
+      government agencies, and other organizations to manage cybersecurity risks.
+      It offers a taxonomy of high level cybersecurity outcomes that can be used
+      by any organization — regardless of its size, sector, or maturity — to
+      better understand, assess, prioritize, and communicate its cybersecurity
+      efforts. The CSF does not prescribe how outcomes should be achieved.
+      Rather, it links to online resources that provide additional guidance on
+      practices and controls that could be used to achieve those outcomes.
+  - id: OpenCRE
+    title: Open Common Requirement Enumeration
+    version: ""
+    url: https://www.opencre.org/
+    description: |
+      An interactive content linking platform for uniting security
+      standards and guidelines. It offers easy and robust access to relevant
+      information when designing, developing, testing and procuring secure software.
+  - id: PCIDSS
+    title: Payment Card Industry Data Security Standard
+    version: "4.0.1"
+    url: https://docs-prv.pcisecuritystandards.org/PCI%20DSS/Standard/PCI-DSS-v4_0_1.pdf
+    description: |
+      PCI Security Standards are technical and operational requirements
+      set by the PCI Security Standards Council (PCI SSC) to protect cardholder
+      data. The standards apply to all entities that store, process or transmit
+      cardholder data – with requirements for software developers and manufacturers
+      of applications and devices used in those transactions. The Council is
+      responsible for managing the security standards, while compliance with the
+      PCI set of standards is enforced by the founding members of the Council:
+      American Express, Discover Financial Services, JCB, MasterCard and Visa Inc.
+      The PCI Data Security Standard (PCI DSS) applies to all entities that store,
+      process, and/or transmit cardholder data. It covers technical and operational
+      system components included in or connected to cardholder data. If you accept
+      or process payment cards, PCI DSS applies to you.
+  - id: SAMM
+    title: OWASP Software Assurance Maturity Model
+    version: "2"
+    url: https://owaspsamm.org/model/
+    description: |
+      A maturity model for software assurance that provides an effective
+      and measurable way for all types of organizations to analyze and improve their
+      software security posture. OWASP SAMM supports the complete software lifecycle,
+      including development and acquisition, and is technology and process agnostic.
+      It is intentionally built to be evolutive and risk-driven in nature.
+  - id: SSDF
+    title: NIST Secure Software Development Framework (SP 800-218)
+    version: "1.1"
+    url: https://csrc.nist.gov/pubs/sp/800/218/final
+    description: |
+      The Secure Software Development Framework (SSDF) is a set of fundamental,
+      sound, and secure software development practices based on established
+      secure software development practice documents from organizations such as
+      BSA, OWASP, and SAFECode. Few software development life cycle (SDLC) models
+      explicitly address software security in detail, so practices like those in
+      the SSDF need to be added to and integrated with each SDLC implementation.
+      Following the SSDF practices should help software producers reduce the
+      number of vulnerabilities in released software, reduce the potential impact
+      of the exploitation of undetected or unaddressed vulnerabilities, and
+      address the root causes of vulnerabilities to prevent recurrences. Also,
+      because the SSDF provides a common language for describing secure software
+      development practices, software producers and acquirers can use it to foster
+      their communications for procurement processes and other management activities.
+  - id: SLSA
+    title: Supply-chain Levels for Software Artifacts
+    version: "1.0"
+    url: https://slsa.dev/
+    description: |
+      SLSA (pronounced \"salsa\") is a security framework from source
+      to service, giving anyone working with software a common language for
+      increasing levels of software security and supply chain integrity. It’s how
+      you get from safe enough to being as resilient as possible, at any link in
+      the chain.
+  - id: ISO-18974
+    title: ISO/IEC 18974
+    version: "1.0 - 2023-12"
+    url: https://openchainproject.org/security-assurance
+    description: |
+      ISO/IEC 18974 helps organizations check open source for known security
+      vulnerability issues like CVEs, GitHub dependency alerts or package manager
+      alerts. ISO/IEC 18974 identifies: The key places to have security processes,
+      How to assign roles and responsibilities, And how to ensure sustainability
+      of the processes. ISO/IEC 18974 is lightweight, easy to read and is
+      supported by our global community with free reference material and
+      conformance resources.
+  - id: PSSCRM
+    title: Proactive Software Supply Chain Risk Management Framework
+    version: ""
+    url: https://arxiv.org/pdf/2404.12300
+    description: |
+      The Proactive-Software Supply Chain Risk Management (P-SSCRM) Framework is
+      designed to help you understand and plan a secure software supply chain risk
+      management initiative. P-SSCRM was created through a process of understanding
+      and analyzing real-world data from nine industry-leading software supply chain
+      risk management initiatives as well as through the analysis and unification
+      of ten government and industry documents, frameworks, and standards. Although
+      individual methodologies and standards differ, many initiatives and standards
+      share common ground. P-SSCRM describes this common ground and presents a model
+      for understanding, quantifying, and developing a secure software supply chain
+      risk management program and determining where your organization's existing
+      efforts stand when contrasted with other real-world software supply chain
+      risk management initiatives.
+  - id: UKSSCOP
+    title: UK Secure Software Compliance or Practices
+    version: "7 May 2025"
+    url: https://www.gov.uk/government/publications/software-security-code-of-practice/software-security-code-of-practice
+    description: |
+      This voluntary Software Security Code of Practice has been developed to
+      improve the security and resilience of software that organisations and
+      businesses rely on.  
+      The Software Security Code of Practice will support software vendors and
+      their customers in reducing the likelihood and impact of software supply
+      chain attacks and other software resilience incidents. Often, these kinds
+      of attacks and disruptions are caused by avoidable weaknesses in software
+      development and maintenance practices. The impact of these kinds of incidents
+      can also be exacerbated by poor communication between organisations and
+      their software suppliers. This Code addresses those issues.
+  - id: Scorecard
+    title: OpenSSF Scorecard
+    version: "v5.2.1"
+    url: "https://scorecard.dev/"
+    description: |
+      An OpenSSF project that helps users assesses open 
+      source projects for security risks through a series 
+      of automated checks. It was created by OSS developers 
+      to help improve the health of critical projects
+      that the community depends on.


### PR DESCRIPTION
This is related to, but not dependent on or blocking #349

I noticed that some of the framework names could have clearer IDs, and since we aren't restricted by length, I've proposed:

- `ScCrd` -> `Scorecard`
- `OCRE` -> `OpenCRE`
- `OC` -> `ISO-18974`

For review simplicity, I'd like to do this prior to migrating to the full use of metadata.yaml in a subsequent PR