### PR TITLE
chore: clarify usage of setup-java in ci workflow

### DIFF
--- a/.github/workflows/oscal-check.yaml
+++ b/.github/workflows/oscal-check.yaml
@@ -36,7 +36,7 @@ jobs:
           check-latest: true
           cache: true
 
-      - name: Setup Java
+      - name: Setup Java # this is here because oscal-cli-action below needs a java runtime
         uses: actions/setup-java@c5195efecf7bdfc987ee8bae7a71cb8b11521c00
         id: setup-java
         with:


### PR DESCRIPTION
Motivated by my earlier confusion when reviewing https://github.com/ossf/security-baseline/pull/380