### PR TITLE
Update Current Version link in nav

### DIFF
--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -46,7 +46,7 @@ minima:
 #     the order they should be rendered.
    nav_pages:
      - index.md
-     - versions/2025-02-25.md
+     - versions/2025-10-10.md
      - faq.md
      - maintenance.md
 #


### PR DESCRIPTION
Updates the explicit list of pages to be included in the top nav, as set in the _config.yml file's nav_pages section, setting the 10-10 release as the Current Version link.