### PR TITLE
Add UKSSCOP reference-ids and claims to OSPS-AC.yaml

### DIFF
--- a/baseline/OSPS-AC.yaml
+++ b/baseline/OSPS-AC.yaml
@@ -142,7 +142,6 @@ controls:
           - reference-id: CM-7
       - reference-id: UKSSCOP
         entries:
-          - reference-id: Claim 2.1.2
           - reference-id: Claim 2.2.2   
     assessment-requirements:
       - id: OSPS-AC-02.01

--- a/baseline/OSPS-AC.yaml
+++ b/baseline/OSPS-AC.yaml
@@ -299,7 +299,7 @@ controls:
           - reference-id: CM-7
       - reference-id: UKSSCOP
         entries:
-          - reference-id: Claim 2.1.2
+          - reference-id: Claim 2.1.1
           - reference-id: Claim 2.1.3   
           - reference-id: Claim 2.2.2   
     assessment-requirements:

--- a/baseline/OSPS-AC.yaml
+++ b/baseline/OSPS-AC.yaml
@@ -71,6 +71,11 @@ controls:
           - reference-id: IA-5
           - reference-id: 1.2e
           - reference-id: 1.2f
+      - reference-id: UKSSCOP
+        entries:
+          - reference-id: Claim 1.4.2
+          - reference-id: Claim 2.1.5   
+          - reference-id: Claim 2.2.2   
     assessment-requirements:
       - id: OSPS-AC-01.01
         text: |
@@ -135,6 +140,10 @@ controls:
           - reference-id: AC-6
           - reference-id: CM-5
           - reference-id: CM-7
+      - reference-id: UKSSCOP
+        entries:
+          - reference-id: Claim 2.1.2
+          - reference-id: Claim 2.2.2   
     assessment-requirements:
       - id: OSPS-AC-02.01
         text: |
@@ -199,6 +208,9 @@ controls:
           - reference-id: CM-3
           - reference-id: CM-3(2)
           - reference-id: CM-5
+      - reference-id: UKSSCOP
+        entries:
+          - reference-id: Claim 2.2.2
     assessment-requirements:
       - id: OSPS-AC-03.01
         text: |
@@ -286,6 +298,11 @@ controls:
           - reference-id: AC-20(1)
           - reference-id: CM-5
           - reference-id: CM-7
+      - reference-id: UKSSCOP
+        entries:
+          - reference-id: Claim 2.1.2
+          - reference-id: Claim 2.1.3   
+          - reference-id: Claim 2.2.2   
     assessment-requirements:
       - id: OSPS-AC-04.01
         text: |

--- a/baseline/OSPS-AC.yaml
+++ b/baseline/OSPS-AC.yaml
@@ -209,6 +209,7 @@ controls:
           - reference-id: CM-5
       - reference-id: UKSSCOP
         entries:
+          - reference-id: Claim 1.1.4
           - reference-id: Claim 2.2.2
     assessment-requirements:
       - id: OSPS-AC-03.01

--- a/baseline/OSPS-AC.yaml
+++ b/baseline/OSPS-AC.yaml
@@ -58,9 +58,6 @@ controls:
           - reference-id: 2.2.1
           - reference-id: 8.2.1
           - reference-id: 8.3.1
-      - reference-id: UKSSCOP
-        entries:
-          - reference-id: 2.1
       - reference-id: 800-161
         entries:
           - reference-id: AC-4(21)
@@ -128,9 +125,6 @@ controls:
       - reference-id: PCIDSS
         entries:
           - reference-id: 2.2.1
-      - reference-id: UKSSCOP
-        entries:
-          - reference-id: 2.1
       - reference-id: 800-161
         entries:
           - reference-id: AC-2
@@ -196,10 +190,6 @@ controls:
       - reference-id: PCIDSS
         entries:
           - reference-id: 2.2.1
-      - reference-id: UKSSCOP
-        entries:
-          - reference-id: 2.1
-          - reference-id: 2.2
       - reference-id: 800-161
         entries:
           - reference-id: AC-3
@@ -284,10 +274,6 @@ controls:
         entries:
           - reference-id: 2.2.1
           - reference-id: 8.2.1
-      - reference-id: UKSSCOP
-        entries:
-          - reference-id: 2.1
-          - reference-id: 2.2
       - reference-id: 800-161
         entries:
           - reference-id: AC-3(8)


### PR DESCRIPTION
Dependent upon merge of  https://github.com/ossf/security-baseline/pull/426

AC mappings to UKSSCOP framework