### PR TITLE
Add UKSSCOP reference-ids and claims to OSPS-GV.yaml

### DIFF
--- a/baseline/OSPS-GV.yaml
+++ b/baseline/OSPS-GV.yaml
@@ -171,7 +171,7 @@ controls:
           - reference-id: AC-3
           - reference-id: AC-20
           - reference-id: PL-1          
-      - reference-id: UKSSCP
+      - reference-id: UKSSCOP
         entries:
           - reference-id: Claim 2.1.1
     assessment-requirements:


### PR DESCRIPTION
Added UKSSCOP reference IDs and claims to multiple sections.

Dependent upon merge of #426

GV mappings to UKSSCOP framework