### PR TITLE
fix(docs): bulleted list in maintainer guidance formatting

### DIFF
--- a/docs/maintainers.md
+++ b/docs/maintainers.md
@@ -18,8 +18,8 @@ Many tools for Baseline evaluation will use this to evaluate controls that are n
 
 To get started with Security Insights:
 
-. Adopt the Security Insights specification by creating a security-insights.yml file in your repository.
-. Populate the security-insights.yml file with security data for your project following the example-full.yml template.
+* Adopt the Security Insights specification by creating a security-insights.yml file in your repository.
+* Populate the security-insights.yml file with security data for your project following the example-full.yml template.
 
 ## Evaluation tooling
 


### PR DESCRIPTION
Corrects markdown issues in bulleted list [shown in](https://baseline.openssf.org/maintainers.html):

<img width="1005" height="351" alt="Screenshot 2025-11-20 at 1 17 25 PM" src="https://github.com/user-attachments/assets/b3f58ae6-dba4-481d-833e-2b9b10ff18d6" />
