### PR TITLE
Fix newlines and generation script for Windows

### DIFF
--- a/cmd/pkg/baseline/template-functions.go
+++ b/cmd/pkg/baseline/template-functions.go
@@ -15,7 +15,9 @@ import (
 )
 
 func collapseNewlines(s string) string {
-	return strings.ReplaceAll(s, "\n", " ")
+	s = strings.ReplaceAll(s, "\r\n", " ")
+	s = strings.ReplaceAll(s, "\n", " ")
+	return strings.TrimSpace(s)
 }
 
 func containsSynonym(list []string, entryTerm, term string) bool {

--- a/docs/versions/2025-10-10-checklist.md
+++ b/docs/versions/2025-10-10-checklist.md
@@ -2,71 +2,71 @@
 
 ## Level 1
 
-- [ ] **OSPS-AC-01.01**: When a user attempts to read or modify a sensitive resource in the project&#39;s authoritative repository, the system MUST require the user to complete a multi-factor authentication process. 
-- [ ] **OSPS-AC-02.01**: When a new collaborator is added, the version control system MUST require manual permission assignment, or restrict the collaborator permissions to the lowest available privileges by default. 
-- [ ] **OSPS-AC-03.01**: When a direct commit is attempted on the project&#39;s primary branch, an enforcement mechanism MUST prevent the change from being applied. 
-- [ ] **OSPS-AC-03.02**: When an attempt is made to delete the project&#39;s primary branch, the version control system MUST treat this as a sensitive activity and require explicit confirmation of intent. 
-- [ ] **OSPS-BR-01.01**: When a CI/CD pipeline accepts an input parameter, that parameter MUST be sanitized and validated prior to use in the pipeline. 
-- [ ] **OSPS-BR-01.02**: When a CI/CD pipeline uses a branch name in its functionality, that name value MUST be sanitized and validated prior to use in the pipeline. 
-- [ ] **OSPS-BR-03.01**: When the project lists a URI as an official project channel, that URI MUST be exclusively delivered using encrypted channels. 
-- [ ] **OSPS-BR-03.02**: When the project lists a URI as an official distribution channel, that URI MUST be exclusively delivered using encrypted channels. 
-- [ ] **OSPS-BR-07.01**: The project MUST prevent the unintentional storage of unencrypted sensitive data, such as secrets and credentials, in the version control system. 
-- [ ] **OSPS-DO-01.01**: When the project has made a release, the project documentation MUST include user guides for all basic functionality. 
-- [ ] **OSPS-DO-02.01**: When the project has made a release, the project documentation MUST include a guide for reporting defects. 
-- [ ] **OSPS-GV-02.01**: While active, the project MUST have one or more mechanisms for public discussions about proposed changes and usage obstacles. 
-- [ ] **OSPS-GV-03.01**: While active, the project documentation MUST include an explanation of the contribution process. 
-- [ ] **OSPS-LE-02.01**: While active, the license for the source code MUST meet the OSI Open Source Definition or the FSF Free Software Definition. 
-- [ ] **OSPS-LE-02.02**: While active, the license for the released software assets MUST meet the OSI Open Source Definition or the FSF Free Software Definition. 
-- [ ] **OSPS-LE-03.01**: While active, the license for the source code MUST be maintained in the corresponding repository&#39;s LICENSE file, COPYING file, or LICENSE/ directory. 
-- [ ] **OSPS-LE-03.02**: While active, the license for the released software assets MUST be included in the released source code, or in a LICENSE file, COPYING file, or LICENSE/ directory alongside the corresponding release assets. 
-- [ ] **OSPS-QA-01.01**: While active, the project&#39;s source code repository MUST be publicly readable at a static URL. 
-- [ ] **OSPS-QA-01.02**: The version control system MUST contain a publicly readable record of all changes made, who made the changes, and when the changes were made. 
-- [ ] **OSPS-QA-02.01**: When the package management system supports it, the source code repository MUST contain a dependency list that accounts for the direct language dependencies. 
-- [ ] **OSPS-QA-04.01**: While active, the project documentation MUST contain a list of any codebases that are considered subprojects. 
-- [ ] **OSPS-QA-05.01**: While active, the version control system MUST NOT contain generated executable artifacts. 
-- [ ] **OSPS-QA-05.02**: While active, the version control system MUST NOT contain unreviewable binary artifacts. 
-- [ ] **OSPS-VM-02.01**: While active, the project documentation MUST contain security contacts. 
+- [ ] **OSPS-AC-01.01**: When a user attempts to read or modify a sensitive resource in the project&#39;s authoritative repository, the system MUST require the user to complete a multi-factor authentication process.
+- [ ] **OSPS-AC-02.01**: When a new collaborator is added, the version control system MUST require manual permission assignment, or restrict the collaborator permissions to the lowest available privileges by default.
+- [ ] **OSPS-AC-03.01**: When a direct commit is attempted on the project&#39;s primary branch, an enforcement mechanism MUST prevent the change from being applied.
+- [ ] **OSPS-AC-03.02**: When an attempt is made to delete the project&#39;s primary branch, the version control system MUST treat this as a sensitive activity and require explicit confirmation of intent.
+- [ ] **OSPS-BR-01.01**: When a CI/CD pipeline accepts an input parameter, that parameter MUST be sanitized and validated prior to use in the pipeline.
+- [ ] **OSPS-BR-01.02**: When a CI/CD pipeline uses a branch name in its functionality, that name value MUST be sanitized and validated prior to use in the pipeline.
+- [ ] **OSPS-BR-03.01**: When the project lists a URI as an official project channel, that URI MUST be exclusively delivered using encrypted channels.
+- [ ] **OSPS-BR-03.02**: When the project lists a URI as an official distribution channel, that URI MUST be exclusively delivered using encrypted channels.
+- [ ] **OSPS-BR-07.01**: The project MUST prevent the unintentional storage of unencrypted sensitive data, such as secrets and credentials, in the version control system.
+- [ ] **OSPS-DO-01.01**: When the project has made a release, the project documentation MUST include user guides for all basic functionality.
+- [ ] **OSPS-DO-02.01**: When the project has made a release, the project documentation MUST include a guide for reporting defects.
+- [ ] **OSPS-GV-02.01**: While active, the project MUST have one or more mechanisms for public discussions about proposed changes and usage obstacles.
+- [ ] **OSPS-GV-03.01**: While active, the project documentation MUST include an explanation of the contribution process.
+- [ ] **OSPS-LE-02.01**: While active, the license for the source code MUST meet the OSI Open Source Definition or the FSF Free Software Definition.
+- [ ] **OSPS-LE-02.02**: While active, the license for the released software assets MUST meet the OSI Open Source Definition or the FSF Free Software Definition.
+- [ ] **OSPS-LE-03.01**: While active, the license for the source code MUST be maintained in the corresponding repository&#39;s LICENSE file, COPYING file, or LICENSE/ directory.
+- [ ] **OSPS-LE-03.02**: While active, the license for the released software assets MUST be included in the released source code, or in a LICENSE file, COPYING file, or LICENSE/ directory alongside the corresponding release assets.
+- [ ] **OSPS-QA-01.01**: While active, the project&#39;s source code repository MUST be publicly readable at a static URL.
+- [ ] **OSPS-QA-01.02**: The version control system MUST contain a publicly readable record of all changes made, who made the changes, and when the changes were made.
+- [ ] **OSPS-QA-02.01**: When the package management system supports it, the source code repository MUST contain a dependency list that accounts for the direct language dependencies.
+- [ ] **OSPS-QA-04.01**: While active, the project documentation MUST contain a list of any codebases that are considered subprojects.
+- [ ] **OSPS-QA-05.01**: While active, the version control system MUST NOT contain generated executable artifacts.
+- [ ] **OSPS-QA-05.02**: While active, the version control system MUST NOT contain unreviewable binary artifacts.
+- [ ] **OSPS-VM-02.01**: While active, the project documentation MUST contain security contacts.
 
 ## Level 2
 
-- [ ] **OSPS-AC-04.01**: When a CI/CD task is executed with no permissions specified, the CI/CD system MUST default the task&#39;s permissions to the lowest permissions granted in the pipeline. 
-- [ ] **OSPS-BR-02.01**: When an official release is created, that release MUST be assigned a unique version identifier. 
-- [ ] **OSPS-BR-04.01**: When an official release is created, that release MUST contain a descriptive log of functional and security modifications. 
-- [ ] **OSPS-BR-05.01**: When a build and release pipeline ingests dependencies, it MUST use standardized tooling where available. 
-- [ ] **OSPS-BR-06.01**: When an official release is created, that release MUST be signed or accounted for in a signed manifest including each asset&#39;s cryptographic hashes. 
-- [ ] **OSPS-DO-06.01**: When the project has made a release, the project documentation MUST include a description of how the project selects, obtains, and tracks its dependencies. 
-- [ ] **OSPS-GV-01.01**: While active, the project documentation MUST include a list of project members with access to sensitive resources. 
-- [ ] **OSPS-GV-01.02**: While active, the project documentation MUST include descriptions of the roles and responsibilities for members of the project. 
-- [ ] **OSPS-GV-03.02**: While active, the project documentation MUST include a guide for code contributors that includes requirements for acceptable contributions. 
-- [ ] **OSPS-LE-01.01**: While active, the version control system MUST require all code contributors to assert that they are legally authorized to make the associated contributions on every commit. 
-- [ ] **OSPS-QA-03.01**: When a commit is made to the primary branch, any automated status checks for commits MUST pass or be manually bypassed. 
-- [ ] **OSPS-QA-06.01**: Prior to a commit being accepted, the project&#39;s CI/CD pipelines MUST run at least one automated test suite to ensure the changes meet expectations. 
-- [ ] **OSPS-SA-01.01**: When the project has made a release, the project documentation MUST include design documentation demonstrating all actions and actors within the system. 
-- [ ] **OSPS-SA-02.01**: When the project has made a release, the project documentation MUST include descriptions of all external software interfaces of the released software assets. 
-- [ ] **OSPS-SA-03.01**: When the project has made a release, the project MUST perform a security assessment to understand the most likely and impactful potential security problems that could occur within the software. 
-- [ ] **OSPS-VM-01.01**: While active, the project documentation MUST include a policy for coordinated vulnerability disclosure (CVD), with a clear timeframe for response. 
-- [ ] **OSPS-VM-03.01**: While active, the project documentation MUST provide a means for private vulnerability reporting directly to the security contacts within the project. 
-- [ ] **OSPS-VM-04.01**: While active, the project documentation MUST publicly publish data about discovered vulnerabilities. 
+- [ ] **OSPS-AC-04.01**: When a CI/CD task is executed with no permissions specified, the CI/CD system MUST default the task&#39;s permissions to the lowest permissions granted in the pipeline.
+- [ ] **OSPS-BR-02.01**: When an official release is created, that release MUST be assigned a unique version identifier.
+- [ ] **OSPS-BR-04.01**: When an official release is created, that release MUST contain a descriptive log of functional and security modifications.
+- [ ] **OSPS-BR-05.01**: When a build and release pipeline ingests dependencies, it MUST use standardized tooling where available.
+- [ ] **OSPS-BR-06.01**: When an official release is created, that release MUST be signed or accounted for in a signed manifest including each asset&#39;s cryptographic hashes.
+- [ ] **OSPS-DO-06.01**: When the project has made a release, the project documentation MUST include a description of how the project selects, obtains, and tracks its dependencies.
+- [ ] **OSPS-GV-01.01**: While active, the project documentation MUST include a list of project members with access to sensitive resources.
+- [ ] **OSPS-GV-01.02**: While active, the project documentation MUST include descriptions of the roles and responsibilities for members of the project.
+- [ ] **OSPS-GV-03.02**: While active, the project documentation MUST include a guide for code contributors that includes requirements for acceptable contributions.
+- [ ] **OSPS-LE-01.01**: While active, the version control system MUST require all code contributors to assert that they are legally authorized to make the associated contributions on every commit.
+- [ ] **OSPS-QA-03.01**: When a commit is made to the primary branch, any automated status checks for commits MUST pass or be manually bypassed.
+- [ ] **OSPS-QA-06.01**: Prior to a commit being accepted, the project&#39;s CI/CD pipelines MUST run at least one automated test suite to ensure the changes meet expectations.
+- [ ] **OSPS-SA-01.01**: When the project has made a release, the project documentation MUST include design documentation demonstrating all actions and actors within the system.
+- [ ] **OSPS-SA-02.01**: When the project has made a release, the project documentation MUST include descriptions of all external software interfaces of the released software assets.
+- [ ] **OSPS-SA-03.01**: When the project has made a release, the project MUST perform a security assessment to understand the most likely and impactful potential security problems that could occur within the software.
+- [ ] **OSPS-VM-01.01**: While active, the project documentation MUST include a policy for coordinated vulnerability disclosure (CVD), with a clear timeframe for response.
+- [ ] **OSPS-VM-03.01**: While active, the project documentation MUST provide a means for private vulnerability reporting directly to the security contacts within the project.
+- [ ] **OSPS-VM-04.01**: While active, the project documentation MUST publicly publish data about discovered vulnerabilities.
 
 ## Level 3
 
-- [ ] **OSPS-AC-04.02**: When a job is assigned permissions in a CI/CD pipeline, the source code or configuration MUST only assign the minimum privileges necessary for the corresponding activity. 
-- [ ] **OSPS-BR-02.02**: When an official release is created, all assets within that release MUST be clearly associated with the release identifier or another unique identifier for the asset. 
-- [ ] **OSPS-BR-07.02**: The project MUST define a policy for managing secrets and credentials used by the project. The policy should include guidelines for storing, accessing, and rotating secrets and credentials. 
-- [ ] **OSPS-DO-03.01**: When the project has made a release, the project documentation MUST contain instructions to verify the integrity and authenticity of the release assets. 
-- [ ] **OSPS-DO-03.02**: When the project has made a release, the project documentation MUST contain instructions to verify the expected identity of the person or process authoring the software release. 
-- [ ] **OSPS-DO-04.01**: When the project has made a release, the project documentation MUST include a descriptive statement about the scope and duration of support for each release. 
-- [ ] **OSPS-DO-05.01**: When the project has made a release, the project documentation MUST provide a descriptive statement when releases or versions will no longer receive security updates. 
-- [ ] **OSPS-GV-04.01**: While active, the project documentation MUST have a policy that code collaborators are reviewed prior to granting escalated permissions to sensitive resources. 
-- [ ] **OSPS-QA-02.02**: When the project has made a release, all compiled released software assets MUST be delivered with a software bill of materials. 
-- [ ] **OSPS-QA-04.02**: When the project has made a release comprising multiple source code repositories, all subprojects MUST enforce security requirements that are as strict or stricter than the primary codebase. 
-- [ ] **OSPS-QA-06.02**: While active, project&#39;s documentation MUST clearly document when and how tests are run. 
-- [ ] **OSPS-QA-06.03**: While active, the project&#39;s documentation MUST include a policy that all major changes to the software produced by the project should add or update tests of the functionality in an automated test suite. 
-- [ ] **OSPS-QA-07.01**: When a commit is made to the primary branch, the project&#39;s version control system MUST require at least one non-author human approval of the changes before merging. 
-- [ ] **OSPS-SA-03.02**: When the project has made a release, the project MUST perform a threat modeling and attack surface analysis to understand and protect against attacks on critical code paths, functions, and interactions within the system. 
-- [ ] **OSPS-VM-04.02**: While active, any vulnerabilities in the software components not affecting the project MUST be accounted for in a VEX document, augmenting the vulnerability report with non-exploitability details. 
-- [ ] **OSPS-VM-05.01**: While active, the project documentation MUST include a policy that defines a threshold for remediation of SCA findings related to vulnerabilities and licenses. 
-- [ ] **OSPS-VM-05.02**: While active, the project documentation MUST include a policy to address SCA violations prior to any release. 
-- [ ] **OSPS-VM-05.03**: While active, all changes to the project&#39;s codebase MUST be automatically evaluated against a documented policy for malicious dependencies and known vulnerabilities in dependencies, then blocked in the event of violations, except when declared and suppressed as non-exploitable. 
-- [ ] **OSPS-VM-06.01**: While active, the project documentation MUST include a policy that defines a threshold for remediation of SAST findings. 
-- [ ] **OSPS-VM-06.02**: While active, all changes to the project&#39;s codebase MUST be automatically evaluated against a documented policy for security weaknesses and blocked in the event of violations except when declared and suppressed as non-exploitable. 
+- [ ] **OSPS-AC-04.02**: When a job is assigned permissions in a CI/CD pipeline, the source code or configuration MUST only assign the minimum privileges necessary for the corresponding activity.
+- [ ] **OSPS-BR-02.02**: When an official release is created, all assets within that release MUST be clearly associated with the release identifier or another unique identifier for the asset.
+- [ ] **OSPS-BR-07.02**: The project MUST define a policy for managing secrets and credentials used by the project. The policy should include guidelines for storing, accessing, and rotating secrets and credentials.
+- [ ] **OSPS-DO-03.01**: When the project has made a release, the project documentation MUST contain instructions to verify the integrity and authenticity of the release assets.
+- [ ] **OSPS-DO-03.02**: When the project has made a release, the project documentation MUST contain instructions to verify the expected identity of the person or process authoring the software release.
+- [ ] **OSPS-DO-04.01**: When the project has made a release, the project documentation MUST include a descriptive statement about the scope and duration of support for each release.
+- [ ] **OSPS-DO-05.01**: When the project has made a release, the project documentation MUST provide a descriptive statement when releases or versions will no longer receive security updates.
+- [ ] **OSPS-GV-04.01**: While active, the project documentation MUST have a policy that code collaborators are reviewed prior to granting escalated permissions to sensitive resources.
+- [ ] **OSPS-QA-02.02**: When the project has made a release, all compiled released software assets MUST be delivered with a software bill of materials.
+- [ ] **OSPS-QA-04.02**: When the project has made a release comprising multiple source code repositories, all subprojects MUST enforce security requirements that are as strict or stricter than the primary codebase.
+- [ ] **OSPS-QA-06.02**: While active, project&#39;s documentation MUST clearly document when and how tests are run.
+- [ ] **OSPS-QA-06.03**: While active, the project&#39;s documentation MUST include a policy that all major changes to the software produced by the project should add or update tests of the functionality in an automated test suite.
+- [ ] **OSPS-QA-07.01**: When a commit is made to the primary branch, the project&#39;s version control system MUST require at least one non-author human approval of the changes before merging.
+- [ ] **OSPS-SA-03.02**: When the project has made a release, the project MUST perform a threat modeling and attack surface analysis to understand and protect against attacks on critical code paths, functions, and interactions within the system.
+- [ ] **OSPS-VM-04.02**: While active, any vulnerabilities in the software components not affecting the project MUST be accounted for in a VEX document, augmenting the vulnerability report with non-exploitability details.
+- [ ] **OSPS-VM-05.01**: While active, the project documentation MUST include a policy that defines a threshold for remediation of SCA findings related to vulnerabilities and licenses.
+- [ ] **OSPS-VM-05.02**: While active, the project documentation MUST include a policy to address SCA violations prior to any release.
+- [ ] **OSPS-VM-05.03**: While active, all changes to the project&#39;s codebase MUST be automatically evaluated against a documented policy for malicious dependencies and known vulnerabilities in dependencies, then blocked in the event of violations, except when declared and suppressed as non-exploitable.
+- [ ] **OSPS-VM-06.01**: While active, the project documentation MUST include a policy that defines a threshold for remediation of SAST findings.
+- [ ] **OSPS-VM-06.02**: While active, all changes to the project&#39;s codebase MUST be automatically evaluated against a documented policy for security weaknesses and blocked in the event of violations except when declared and suppressed as non-exploitable.

--- a/docs/versions/2025-10-10.md
+++ b/docs/versions/2025-10-10.md
@@ -361,8 +361,7 @@ release processes.
 
 
 
-### OSPS-AC-01 -  The [project][Project]&#39;s [version control system][Version Control System] MUST require multi-factor authentication for [users][User] modifying the [project][Project] [repository][Repository] settings or accessing [sensitive data][Sensitive Data].
- 
+### OSPS-AC-01 - The [project][Project]&#39;s [version control system][Version Control System] MUST require multi-factor authentication for [users][User] modifying the [project][Project] [repository][Repository] settings or accessing [sensitive data][Sensitive Data].
 
 
 Reduce the risk of account compromise or insider threats by requiring
@@ -374,9 +373,7 @@ repository settings or accessing sensitive data.
 
 #### OSPS-AC-01.01
 
-**Requirement:**  When a [user][User] attempts to read or modify a [sensitive resource][Sensitive Resource] in the [project][Project]&#39;s authoritative [repository][Repository], the system MUST require the [user][User] to complete
- a [multi-factor authentication][Multi-factor Authentication] process.
- 
+**Requirement:** When a [user][User] attempts to read or modify a [sensitive resource][Sensitive Resource] in the [project][Project]&#39;s authoritative [repository][Repository], the system MUST require the [user][User] to complete a [multi-factor authentication][Multi-factor Authentication] process.
 
 **Recommendation:** 
 Enforce multi-factor authentication for the project&#39;s version
@@ -411,8 +408,7 @@ settings. Passkeys are acceptable for this control.
 
 ---
 
-### OSPS-AC-02 -  The [project][Project]&#39;s [version control system][Version Control System] MUST restrict [collaborator][Collaborator] permissions to the lowest available privileges by default.
- 
+### OSPS-AC-02 - The [project][Project]&#39;s [version control system][Version Control System] MUST restrict [collaborator][Collaborator] permissions to the lowest available privileges by default.
 
 
 Reduce the risk of unauthorized access to the project&#39;s repository by
@@ -423,10 +419,7 @@ limiting the permissions granted to new collaborators.
 
 #### OSPS-AC-02.01
 
-**Requirement:**  When a new [collaborator][Collaborator] is added, the [version control system][Version Control System] MUST
- require manual permission assignment, or restrict the [collaborator][Collaborator]
- permissions to the lowest available privileges by default.
- 
+**Requirement:** When a new [collaborator][Collaborator] is added, the [version control system][Version Control System] MUST require manual permission assignment, or restrict the [collaborator][Collaborator] permissions to the lowest available privileges by default.
 
 **Recommendation:** 
 Most public version control systems are configured in this manner.
@@ -459,8 +452,7 @@ additional permissions only when necessary.
 
 ---
 
-### OSPS-AC-03 -  The [project][Project]&#39;s [version control system][Version Control System] MUST prevent unintentional modification of the [primary branch][Primary Branch].
- 
+### OSPS-AC-03 - The [project][Project]&#39;s [version control system][Version Control System] MUST prevent unintentional modification of the [primary branch][Primary Branch].
 
 
 Reduce the risk of accidental changes or deletion of the primary branch
@@ -471,9 +463,7 @@ of the project&#39;s repository by preventing unintentional modification.
 
 #### OSPS-AC-03.01
 
-**Requirement:**  When a direct [commit][Commit] is attempted on the [project][Project]&#39;s [primary branch][Primary Branch],
- an enforcement mechanism MUST prevent the [change][Change] from being applied.
- 
+**Requirement:** When a direct [commit][Commit] is attempted on the [project][Project]&#39;s [primary branch][Primary Branch], an enforcement mechanism MUST prevent the [change][Change] from being applied.
 
 **Recommendation:** 
 If the VCS is centralized, set branch protection on the primary branch
@@ -493,10 +483,7 @@ specific separate act.
 
 #### OSPS-AC-03.02
 
-**Requirement:**  When an attempt is made to delete the [project][Project]&#39;s [primary branch][Primary Branch],
- the [version control system][Version Control System] MUST treat this as a sensitive activity
- and require explicit confirmation of intent.
- 
+**Requirement:** When an attempt is made to delete the [project][Project]&#39;s [primary branch][Primary Branch], the [version control system][Version Control System] MUST treat this as a sensitive activity and require explicit confirmation of intent.
 
 **Recommendation:** 
 Set branch protection on the primary branch in the project&#39;s version
@@ -528,8 +515,7 @@ control system to prevent deletion.
 
 ---
 
-### OSPS-AC-04 -  The [project][Project]&#39;s permissions in [CI/CD pipelines][CI/CD Pipeline] MUST follow the principle of least privilege.
- 
+### OSPS-AC-04 - The [project][Project]&#39;s permissions in [CI/CD pipelines][CI/CD Pipeline] MUST follow the principle of least privilege.
 
 
 Reduce the risk of unauthorized access to the project&#39;s build and release
@@ -541,10 +527,7 @@ pipelines.
 
 #### OSPS-AC-04.01
 
-**Requirement:**  When a CI/CD task is executed with no permissions specified, the
- CI/CD system MUST default the task&#39;s permissions to the lowest
- permissions granted in the pipeline.
- 
+**Requirement:** When a CI/CD task is executed with no permissions specified, the CI/CD system MUST default the task&#39;s permissions to the lowest permissions granted in the pipeline.
 
 **Recommendation:** 
 Configure the project&#39;s settings to assign the lowest available
@@ -561,10 +544,7 @@ permissions only when necessary for specific tasks.
 
 #### OSPS-AC-04.02
 
-**Requirement:**  When a job is assigned permissions in a [CI/CD pipeline][CI/CD Pipeline], the source
- [code][Code] or configuration MUST only assign the minimum privileges
- necessary for the corresponding activity.
- 
+**Requirement:** When a job is assigned permissions in a [CI/CD pipeline][CI/CD Pipeline], the source [code][Code] or configuration MUST only assign the minimum privileges necessary for the corresponding activity.
 
 **Recommendation:** 
 Configure the project&#39;s CI/CD pipelines to assign the lowest available
@@ -611,8 +591,7 @@ process.
 
 
 
-### OSPS-BR-01 -  The [project][Project]&#39;s [build and release pipelines][Build and Release Pipeline] MUST NOT permit untrusted input that allows access to privileged resources.
- 
+### OSPS-BR-01 - The [project][Project]&#39;s [build and release pipelines][Build and Release Pipeline] MUST NOT permit untrusted input that allows access to privileged resources.
 
 
 Reduce the risk of code injection or other security vulnerabilities in the
@@ -624,9 +603,7 @@ accessing privileged resources.
 
 #### OSPS-BR-01.01
 
-**Requirement:**  When a [CI/CD pipeline][CI/CD Pipeline] accepts an input parameter, that parameter MUST
- be sanitized and validated prior to use in the pipeline.
- 
+**Requirement:** When a [CI/CD pipeline][CI/CD Pipeline] accepts an input parameter, that parameter MUST be sanitized and validated prior to use in the pipeline.
 
 **Recommendation:** 
 
@@ -640,10 +617,7 @@ accessing privileged resources.
 
 #### OSPS-BR-01.02
 
-**Requirement:**  When a [CI/CD pipeline][CI/CD Pipeline] uses a branch name in its functionality, that
- name value MUST be sanitized and validated prior to use in the
- pipeline.
- 
+**Requirement:** When a [CI/CD pipeline][CI/CD Pipeline] uses a branch name in its functionality, that name value MUST be sanitized and validated prior to use in the pipeline.
 
 **Recommendation:** 
 
@@ -670,8 +644,7 @@ accessing privileged resources.
 
 ---
 
-### OSPS-BR-02 -  All [releases][Release] and [released software assets][Released Software Asset] MUST be assigned a unique [version identifier][Version Identifier] for each [release][Release] intended to be used by [users][User].
- 
+### OSPS-BR-02 - All [releases][Release] and [released software assets][Released Software Asset] MUST be assigned a unique [version identifier][Version Identifier] for each [release][Release] intended to be used by [users][User].
 
 
 Ensure that each software asset produced by the project is uniquely
@@ -683,9 +656,7 @@ over time.
 
 #### OSPS-BR-02.01
 
-**Requirement:**  When an official [release][Release] is created, that [release][Release] MUST be assigned a
- unique [version identifier][Version Identifier].
- 
+**Requirement:** When an official [release][Release] is created, that [release][Release] MUST be assigned a unique [version identifier][Version Identifier].
 
 **Recommendation:** 
 Assign a unique version identifier to each release produced by the
@@ -702,10 +673,7 @@ Examples include SemVer, CalVer, or git commit id.
 
 #### OSPS-BR-02.02
 
-**Requirement:**  When an official [release][Release] is created, all assets within that [release][Release]
- MUST be clearly associated with the [release][Release] identifier or another
- unique identifier for the asset.
- 
+**Requirement:** When an official [release][Release] is created, all assets within that [release][Release] MUST be clearly associated with the [release][Release] identifier or another unique identifier for the asset.
 
 **Recommendation:** 
 Assign a unique version identifier to each software asset produced by
@@ -736,8 +704,7 @@ scheme. Examples include SemVer, CalVer, or git commit id.
 
 ---
 
-### OSPS-BR-03 -  All official [project][Project] URIs MUST be delivered using encrypted channels.
- 
+### OSPS-BR-03 - All official [project][Project] URIs MUST be delivered using encrypted channels.
 
 
 Protect the confidentiality and integrity of project source code during
@@ -748,9 +715,7 @@ development, reducing the risk of eavesdropping or data tampering.
 
 #### OSPS-BR-03.01
 
-**Requirement:**  When the [project][Project] lists a URI as an official [project][Project] channel, that URI
- MUST be exclusively delivered using encrypted channels.
- 
+**Requirement:** When the [project][Project] lists a URI as an official [project][Project] channel, that URI MUST be exclusively delivered using encrypted channels.
 
 **Recommendation:** 
 Configure the project&#39;s websites and version control systems to use
@@ -769,9 +734,7 @@ only be accessed via encrypted channels.
 
 #### OSPS-BR-03.02
 
-**Requirement:**  When the [project][Project] lists a URI as an official distribution channel,
- that URI MUST be exclusively delivered using encrypted channels.
- 
+**Requirement:** When the [project][Project] lists a URI as an official distribution channel, that URI MUST be exclusively delivered using encrypted channels.
 
 **Recommendation:** 
 Configure the project&#39;s release pipeline to only fetch data from
@@ -804,9 +767,7 @@ channels such as SSH or HTTPS for data transmission.
 
 ---
 
-### OSPS-BR-04 -  All [releases][Release] MUST provide a descriptive log of functional and security
- modifications.
- 
+### OSPS-BR-04 - All [releases][Release] MUST provide a descriptive log of functional and security modifications.
 
 
 Provide transparency and accountability for changes made to the project&#39;s
@@ -818,10 +779,7 @@ improvements included in each release.
 
 #### OSPS-BR-04.01
 
-**Requirement:**  When an official [release][Release] is created, that [release][Release] MUST contain
- a descriptive log of functional and security
- modifications.
- 
+**Requirement:** When an official [release][Release] is created, that [release][Release] MUST contain a descriptive log of functional and security modifications.
 
 **Recommendation:** 
 Ensure that all releases include a descriptive change log. It is
@@ -856,9 +814,7 @@ such as &#34;## Changelog&#34;.
 
 ---
 
-### OSPS-BR-05 -  All [build and release pipelines][Build and Release Pipeline] MUST use standardized tooling where
- available to ingest dependencies at build time.
- 
+### OSPS-BR-05 - All [build and release pipelines][Build and Release Pipeline] MUST use standardized tooling where available to ingest dependencies at build time.
 
 
 Ensure that the project&#39;s build and release pipelines use standardized tools
@@ -870,9 +826,7 @@ issues or security vulnerabilities in the software.
 
 #### OSPS-BR-05.01
 
-**Requirement:**  When a [build and release pipeline][Build and Release Pipeline] ingests dependencies, it MUST
- use standardized tooling where available.
- 
+**Requirement:** When a [build and release pipeline][Build and Release Pipeline] ingests dependencies, it MUST use standardized tooling where available.
 
 **Recommendation:** 
 Use a common tooling for your ecosystem, such as package managers or
@@ -907,8 +861,7 @@ system.
 
 ---
 
-### OSPS-BR-06 -  Produce all [released software assets][Released Software Asset] with signatures and hashes.
- 
+### OSPS-BR-06 - Produce all [released software assets][Released Software Asset] with signatures and hashes.
 
 
 All released software assets MUST be signed or accounted for in a
@@ -919,10 +872,7 @@ signed manifest including each asset&#39;s cryptographic hashes.
 
 #### OSPS-BR-06.01
 
-**Requirement:**  When an official [release][Release] is created, that [release][Release] MUST be signed or
- accounted for in a signed manifest including each asset&#39;s
- cryptographic hashes.
- 
+**Requirement:** When an official [release][Release] is created, that [release][Release] MUST be signed or accounted for in a signed manifest including each asset&#39;s cryptographic hashes.
 
 **Recommendation:** 
 Sign all released software assets at build time with a cryptographic
@@ -953,8 +903,7 @@ hashes of each asset in a signed manifest or metadata file.
 
 ---
 
-### OSPS-BR-07 -  The [project][Project] MUST store and manage all secrets and credentials used by the [project][Project] in a secure manner.
- 
+### OSPS-BR-07 - The [project][Project] MUST store and manage all secrets and credentials used by the [project][Project] in a secure manner.
 
 
 Ensure that sensitive data is not disclosed, compromised or misused leading to security vulnerabilities or supply chain compromise.
@@ -964,8 +913,7 @@ Ensure that sensitive data is not disclosed, compromised or misused leading to s
 
 #### OSPS-BR-07.01
 
-**Requirement:**  The [project][Project] MUST prevent the unintentional storage of unencrypted [sensitive data][Sensitive Data], such as secrets and credentials, in the [version control system][Version Control System].
- 
+**Requirement:** The [project][Project] MUST prevent the unintentional storage of unencrypted [sensitive data][Sensitive Data], such as secrets and credentials, in the [version control system][Version Control System].
 
 **Recommendation:** 
 Configure .gitignore or equivalent to exclude files that may contain sensitive information. Use pre-commit hooks and automated scanning tools to detect and prevent the inclusion of sensitive data in commits.
@@ -979,8 +927,7 @@ Configure .gitignore or equivalent to exclude files that may contain sensitive i
 
 #### OSPS-BR-07.02
 
-**Requirement:**  The [project][Project] MUST define a policy for managing secrets and credentials used by the [project][Project]. The policy should include guidelines for storing, accessing, and rotating secrets and credentials.
- 
+**Requirement:** The [project][Project] MUST define a policy for managing secrets and credentials used by the [project][Project]. The policy should include guidelines for storing, accessing, and rotating secrets and credentials.
 
 **Recommendation:** 
 Document how secrets and credentials are managed and used within the project. This should include details on how secrets are stored (e.g., using a secrets management tool), how access is controlled, and how secrets are rotated or updated. Ensure that sensitive information is not hard-coded in the source code or stored in version control systems.
@@ -1015,8 +962,7 @@ security and release practices.
 
 
 
-### OSPS-DO-01 -  The [project][Project] documentation MUST provide [user][User] guides for all basic functionality.
- 
+### OSPS-DO-01 - The [project][Project] documentation MUST provide [user][User] guides for all basic functionality.
 
 
 Ensure that users have a clear and comprehensive understanding of the
@@ -1028,9 +974,7 @@ misconfiguration.
 
 #### OSPS-DO-01.01
 
-**Requirement:**  When the [project][Project] has made a [release][Release], the [project][Project] documentation MUST
- include [user][User] guides for all basic functionality.
- 
+**Requirement:** When the [project][Project] has made a [release][Release], the [project][Project] documentation MUST include [user][User] guides for all basic functionality.
 
 **Recommendation:** 
 Create user guides or documentation for all basic functionality of the
@@ -1065,8 +1009,7 @@ available, include highly-visible warnings.
 
 ---
 
-### OSPS-DO-02 -  The [project][Project] MUST provide a mechanism for reporting [defects][Defect].
- 
+### OSPS-DO-02 - The [project][Project] MUST provide a mechanism for reporting [defects][Defect].
 
 
 Enable users and contributors to report defects or issues with the
@@ -1078,9 +1021,7 @@ defect fixes and improvements.
 
 #### OSPS-DO-02.01
 
-**Requirement:**  When the [project][Project] has made a [release][Release], the [project][Project] documentation MUST
- include a guide for reporting [defects][Defect].
- 
+**Requirement:** When the [project][Project] has made a [release][Release], the [project][Project] documentation MUST include a guide for reporting [defects][Defect].
 
 **Recommendation:** 
 It is recommended that projects use their VCS default issue tracker.
@@ -1115,8 +1056,7 @@ sets expectations for how defects will be triaged and resolved.
 
 ---
 
-### OSPS-DO-03 -  The [project][Project] documentation MUST contain instructions to verify the integrity and authenticity of the [release][Release] assets, including the expected identity of the [person][User] or process authoring the software [release][Release].
- 
+### OSPS-DO-03 - The [project][Project] documentation MUST contain instructions to verify the integrity and authenticity of the [release][Release] assets, including the expected identity of the [person][User] or process authoring the software [release][Release].
 
 
 Enable users to verify the authenticity and integrity of the project&#39;s
@@ -1128,10 +1068,7 @@ unauthorized versions of the software.
 
 #### OSPS-DO-03.01
 
-**Requirement:**  When the [project][Project] has made a [release][Release], the [project][Project] documentation MUST
- contain instructions to verify the integrity and authenticity of the
- [release][Release] assets.
- 
+**Requirement:** When the [project][Project] has made a [release][Release], the [project][Project] documentation MUST contain instructions to verify the integrity and authenticity of the [release][Release] assets.
 
 **Recommendation:** 
 Instructions in the project should contain information about the
@@ -1150,10 +1087,7 @@ integrity of the software.
 
 #### OSPS-DO-03.02
 
-**Requirement:**  When the [project][Project] has made a [release][Release], the [project][Project] documentation MUST
- contain instructions to verify the expected identity of the [person][User] or
- process authoring the software [release][Release].
- 
+**Requirement:** When the [project][Project] has made a [release][Release], the [project][Project] documentation MUST contain instructions to verify the expected identity of the [person][User] or process authoring the software [release][Release].
 
 **Recommendation:** 
 The expected identity may be in the form of key IDs used to sign,
@@ -1187,8 +1121,7 @@ integrity of the software.
 
 ---
 
-### OSPS-DO-04 -  The [project][Project] documentation MUST include a descriptive statement about the scope and duration of support.
- 
+### OSPS-DO-04 - The [project][Project] documentation MUST include a descriptive statement about the scope and duration of support.
 
 
 Provide users with clear expectations regarding the project&#39;s support
@@ -1200,10 +1133,7 @@ ensure the continued functionality and security of their systems.
 
 #### OSPS-DO-04.01
 
-**Requirement:**  When the [project][Project] has made a [release][Release], the [project][Project] documentation MUST
- include a descriptive statement about the scope and duration of
- support for each [release][Release].
- 
+**Requirement:** When the [project][Project] has made a [release][Release], the [project][Project] documentation MUST include a descriptive statement about the scope and duration of support for each [release][Release].
 
 **Recommendation:** 
 In order to communicate the scope and duration of support for the
@@ -1237,8 +1167,7 @@ any relevant policies or procedures for obtaining support.
 
 ---
 
-### OSPS-DO-05 -  The [project][Project] documentation MUST provide a descriptive statement when [releases][Release] or versions will no longer receive security updates.
- 
+### OSPS-DO-05 - The [project][Project] documentation MUST provide a descriptive statement when [releases][Release] or versions will no longer receive security updates.
 
 
 Communicating when the project maintainers will no longer fix defects or
@@ -1250,10 +1179,7 @@ alternative solutions or alternative means of support for the project.
 
 #### OSPS-DO-05.01
 
-**Requirement:**  When the [project][Project] has made a [release][Release], the [project][Project] documentation MUST
- provide a descriptive statement when [releases][Release] or versions will no
- longer receive security updates.
- 
+**Requirement:** When the [project][Project] has made a [release][Release], the [project][Project] documentation MUST provide a descriptive statement when [releases][Release] or versions will no longer receive security updates.
 
 **Recommendation:** 
 In order to communicate the scope and duration of support for security
@@ -1283,8 +1209,7 @@ explaining the project&#39;s policy for security updates.
 
 ---
 
-### OSPS-DO-06 -  The [project][Project] documentation MUST include a description of how the [project][Project] selects, obtains, and tracks its dependencies.
- 
+### OSPS-DO-06 - The [project][Project] documentation MUST include a description of how the [project][Project] selects, obtains, and tracks its dependencies.
 
 
 Provide information about how the project selects, obtains, and tracks
@@ -1297,10 +1222,7 @@ that are required necessary for the software to function.
 
 #### OSPS-DO-06.01
 
-**Requirement:**  When the [project][Project] has made a [release][Release], the [project][Project] documentation MUST
- include a description of how the [project][Project] selects, obtains, and tracks
- its dependencies.
- 
+**Requirement:** When the [project][Project] has made a [release][Release], the [project][Project] documentation MUST include a description of how the [project][Project] selects, obtains, and tracks its dependencies.
 
 **Recommendation:** 
 It is recommended to publish this information alongside the project&#39;s
@@ -1343,8 +1265,7 @@ both threats and opportunities.
 
 
 
-### OSPS-GV-01 -  The [project][Project] documentation MUST include the roles and responsibilities for members of the [project][Project].
- 
+### OSPS-GV-01 - The [project][Project] documentation MUST include the roles and responsibilities for members of the [project][Project].
 
 
 Documenting project roles and responsibilities helps project participants,
@@ -1357,9 +1278,7 @@ they may have.
 
 #### OSPS-GV-01.01
 
-**Requirement:**  While active, the [project][Project] documentation MUST include a list of
- [project][Project] members with access to [sensitive resources][Sensitive Resource].
- 
+**Requirement:** While active, the [project][Project] documentation MUST include a list of [project][Project] members with access to [sensitive resources][Sensitive Resource].
 
 **Recommendation:** 
 Document project participants and their roles through such artifacts
@@ -1378,9 +1297,7 @@ of maintainers, or more complex depending on the project&#39;s governance.
 
 #### OSPS-GV-01.02
 
-**Requirement:**  While active, the [project][Project] documentation MUST include descriptions of
- the roles and responsibilities for members of the [project][Project].
- 
+**Requirement:** While active, the [project][Project] documentation MUST include descriptions of the roles and responsibilities for members of the [project][Project].
 
 **Recommendation:** 
 Document project participants and their roles through such artifacts
@@ -1408,8 +1325,7 @@ the source code repository of the project.
 
 ---
 
-### OSPS-GV-02 -  The [project][Project] MUST have one or more mechanisms for public discussions about proposed [changes][Change] and usage obstacles.
- 
+### OSPS-GV-02 - The [project][Project] MUST have one or more mechanisms for public discussions about proposed [changes][Change] and usage obstacles.
 
 
 Encourages open communication and collaboration within the project
@@ -1421,9 +1337,7 @@ or usage challenges.
 
 #### OSPS-GV-02.01
 
-**Requirement:**  While active, the [project][Project] MUST have one or more mechanisms for public
- discussions about proposed [changes][Change] and usage obstacles.
- 
+**Requirement:** While active, the [project][Project] MUST have one or more mechanisms for public discussions about proposed [changes][Change] and usage obstacles.
 
 **Recommendation:** 
 Establish one or more mechanisms for public discussions within the
@@ -1452,9 +1366,7 @@ to facilitate open communication and feedback.
 
 ---
 
-### OSPS-GV-03 -  The [project][Project] documentation MUST include an explanation of the
- contribution process.
- 
+### OSPS-GV-03 - The [project][Project] documentation MUST include an explanation of the contribution process.
 
 
 Provide guidance to new contributors on how to participate in the project,
@@ -1466,9 +1378,7 @@ project&#39;s codebase.
 
 #### OSPS-GV-03.01
 
-**Requirement:**  While active, the [project][Project] documentation MUST include an explanation
- of the contribution process.
- 
+**Requirement:** While active, the [project][Project] documentation MUST include an explanation of the contribution process.
 
 **Recommendation:** 
 Create a CONTRIBUTING.md or CONTRIBUTING/ directory to outline the
@@ -1486,9 +1396,7 @@ engaging with the project maintainers.
 
 #### OSPS-GV-03.02
 
-**Requirement:**  While active, the [project][Project] documentation MUST include a guide for [code][Code]
- [contributors][Contributor] that includes requirements for acceptable contributions.
- 
+**Requirement:** While active, the [project][Project] documentation MUST include a guide for [code][Code] [contributors][Contributor] that includes requirements for acceptable contributions.
 
 **Recommendation:** 
 Extend the CONTRIBUTING.md or CONTRIBUTING/ contents in the project
@@ -1520,8 +1428,7 @@ this guide is the source of truth for both contributors and approvers.
 
 ---
 
-### OSPS-GV-04 -  The [project][Project] documentation MUST have a policy that [code][Code] [contributors][Contributor] are reviewed prior to granting escalated permissions to sensitive resources.
- 
+### OSPS-GV-04 - The [project][Project] documentation MUST have a policy that [code][Code] [contributors][Contributor] are reviewed prior to granting escalated permissions to sensitive resources.
 
 
 Ensure that code contributors are vetted and reviewed before being granted
@@ -1533,10 +1440,7 @@ the risk of unauthorized access or misuse.
 
 #### OSPS-GV-04.01
 
-**Requirement:**  While active, the [project][Project] documentation MUST have a policy that [code][Code]
- [collaborators][Collaborator] are reviewed prior to granting escalated permissions to
- [sensitive resources][Sensitive Resource].
- 
+**Requirement:** While active, the [project][Project] documentation MUST have a policy that [code][Code] [collaborators][Collaborator] are reviewed prior to granting escalated permissions to [sensitive resources][Sensitive Resource].
 
 **Recommendation:** 
 Publish an enforceable policy in the project documentation that
@@ -1583,8 +1487,7 @@ disputes or licensing violations.
 
 
 
-### OSPS-LE-01 -  The [version control system][Version Control System] MUST require all [code][Code] [contributors][Contributor] to assert that they are legally authorized to make the associated contributions on every [commit][Commit].
- 
+### OSPS-LE-01 - The [version control system][Version Control System] MUST require all [code][Code] [contributors][Contributor] to assert that they are legally authorized to make the associated contributions on every [commit][Commit].
 
 
 Ensure that code contributors are aware of and acknowledge their legal
@@ -1596,10 +1499,7 @@ the risk of intellectual property disputes against the project.
 
 #### OSPS-LE-01.01
 
-**Requirement:**  While active, the [version control system][Version Control System] MUST require all [code][Code]
- [contributors][Contributor] to assert that they are legally authorized to make the
- associated contributions on every [commit][Commit].
- 
+**Requirement:** While active, the [version control system][Version Control System] MUST require all [code][Code] [contributors][Contributor] to assert that they are legally authorized to make the associated contributions on every [commit][Commit].
 
 **Recommendation:** 
 Include a DCO in the project&#39;s repository, requiring code
@@ -1635,8 +1535,7 @@ requirement.
 
 ---
 
-### OSPS-LE-02 -  All [licenses][License] for the [project][Project] MUST meet the OSI Open Source Definition or the FSF Free Software Definition.
- 
+### OSPS-LE-02 - All [licenses][License] for the [project][Project] MUST meet the OSI Open Source Definition or the FSF Free Software Definition.
 
 
 Ensure that the project&#39;s source code is distributed under a recognized
@@ -1648,9 +1547,7 @@ how the code can be used and shared by others.
 
 #### OSPS-LE-02.01
 
-**Requirement:**  While active, the [license][License] for the source [code][Code] MUST meet the OSI Open
- Source Definition or the FSF Free Software Definition.
- 
+**Requirement:** While active, the [license][License] for the source [code][Code] MUST meet the OSI Open Source Definition or the FSF Free Software Definition.
 
 **Recommendation:** 
 Add a LICENSE file to the project&#39;s repo with a license that is an
@@ -1672,9 +1569,7 @@ this control if there are no other encumbrances such as patents.
 
 #### OSPS-LE-02.02
 
-**Requirement:**  While active, the [license][License] for the [released software assets][Released Software Asset] MUST meet
- the OSI Open Source Definition or the FSF Free Software Definition.
- 
+**Requirement:** While active, the [license][License] for the [released software assets][Released Software Asset] MUST meet the OSI Open Source Definition or the FSF Free Software Definition.
 
 **Recommendation:** 
 If a different license is included with released software assets,
@@ -1710,8 +1605,7 @@ released software assets may be different than the source code.
 
 ---
 
-### OSPS-LE-03 -  All [licenses][License] for the [project][Project]&#39;s source [code][Code] MUST be maintained in a standard location within the corresponding [repository][Repository].
- 
+### OSPS-LE-03 - All [licenses][License] for the [project][Project]&#39;s source [code][Code] MUST be maintained in a standard location within the corresponding [repository][Repository].
 
 
 Ensure that the project&#39;s source code and released software assets are
@@ -1723,10 +1617,7 @@ and contributors how each can be used and shared.
 
 #### OSPS-LE-03.01
 
-**Requirement:**  While active, the [license][License] for the source [code][Code] MUST be maintained in
- the corresponding [repository][Repository]&#39;s [LICENSE][License] file, COPYING file, or
- [LICENSE][License]/ directory.
- 
+**Requirement:** While active, the [license][License] for the source [code][Code] MUST be maintained in the corresponding [repository][Repository]&#39;s [LICENSE][License] file, COPYING file, or [LICENSE][License]/ directory.
 
 **Recommendation:** 
 Include the project&#39;s source code license in the project&#39;s LICENSE
@@ -1746,11 +1637,7 @@ includes the license file.
 
 #### OSPS-LE-03.02
 
-**Requirement:**  While active, the [license][License] for the [released software assets][Released Software Asset] MUST be
- included in the released source [code][Code], or in a [LICENSE][License] file, COPYING
- file, or [LICENSE][License]/ directory alongside the corresponding [release][Release]
- assets.
- 
+**Requirement:** While active, the [license][License] for the [released software assets][Released Software Asset] MUST be included in the released source [code][Code], or in a [LICENSE][License] file, COPYING file, or [LICENSE][License]/ directory alongside the corresponding [release][Release] assets.
 
 **Recommendation:** 
 Include the project&#39;s released software assets license in the released
@@ -1798,8 +1685,7 @@ software.
 
 
 
-### OSPS-QA-01 -  The [project][Project]&#39;s source [code][Code] and [change][Change] history MUST be publicly readable at a static URL.
- 
+### OSPS-QA-01 - The [project][Project]&#39;s source [code][Code] and [change][Change] history MUST be publicly readable at a static URL.
 
 
 Enable users to access and review the project&#39;s source code and history,
@@ -1810,9 +1696,7 @@ promoting transparency and collaboration within the project community.
 
 #### OSPS-QA-01.01
 
-**Requirement:**  While active, the [project][Project]&#39;s source [code][Code] [repository][Repository] MUST be publicly
- readable at a static URL.
- 
+**Requirement:** While active, the [project][Project]&#39;s source [code][Code] [repository][Repository] MUST be publicly readable at a static URL.
 
 **Recommendation:** 
 Use a common VCS such as GitHub, GitLab, or Bitbucket. Ensure the
@@ -1832,10 +1716,7 @@ repository URL. Ensure the repository is public.
 
 #### OSPS-QA-01.02
 
-**Requirement:**  The [version control system][Version Control System] MUST contain a publicly readable record of
- all [changes][Change] made, who made the [changes][Change], and when the [changes][Change] were
- made.
- 
+**Requirement:** The [version control system][Version Control System] MUST contain a publicly readable record of all [changes][Change] made, who made the [changes][Change], and when the [changes][Change] were made.
 
 **Recommendation:** 
 Use a common VCS such as GitHub, GitLab, or Bitbucket to maintain a
@@ -1870,8 +1751,7 @@ in a way that would obscure the author of any commits.
 
 ---
 
-### OSPS-QA-02 -  The [project][Project] MUST provide a list of dependencies used in the software.
- 
+### OSPS-QA-02 - The [project][Project] MUST provide a list of dependencies used in the software.
 
 
 Provide transparency and accountability for the project&#39;s dependencies
@@ -1883,10 +1763,7 @@ dependencies.
 
 #### OSPS-QA-02.01
 
-**Requirement:**  When the package management system supports it, the source [code][Code]
- [repository][Repository] MUST contain a dependency list that accounts for the direct
- language dependencies.
- 
+**Requirement:** When the package management system supports it, the source [code][Code] [repository][Repository] MUST contain a dependency list that accounts for the direct language dependencies.
 
 **Recommendation:** 
 This may take the form of a package manager or language dependency file
@@ -1904,9 +1781,7 @@ or go.mod.
 
 #### OSPS-QA-02.02
 
-**Requirement:**  When the [project][Project] has made a [release][Release], all compiled released software
- assets MUST be delivered with a [software bill of materials][Software Bill of Materials].
- 
+**Requirement:** When the [project][Project] has made a [release][Release], all compiled released software assets MUST be delivered with a [software bill of materials][Software Bill of Materials].
 
 **Recommendation:** 
 It is recommended to auto-generate SBOMs at build time using a tool
@@ -1940,8 +1815,7 @@ environment.
 
 ---
 
-### OSPS-QA-03 -  Any automated [status checks][Status Check] for [commits][Commit] MUST pass or require manual acknowledgement prior to merge.
- 
+### OSPS-QA-03 - Any automated [status checks][Status Check] for [commits][Commit] MUST pass or require manual acknowledgement prior to merge.
 
 
 Ensure that the project&#39;s approvers do not become accustomed to tolerating
@@ -1954,9 +1828,7 @@ checks.
 
 #### OSPS-QA-03.01
 
-**Requirement:**  When a [commit][Commit] is made to the [primary branch][Primary Branch], any automated status
- checks for [commits][Commit] MUST pass or be manually bypassed.
- 
+**Requirement:** When a [commit][Commit] is made to the [primary branch][Primary Branch], any automated status checks for [commits][Commit] MUST pass or be manually bypassed.
 
 **Recommendation:** 
 Configure the project&#39;s version control system to require that all
@@ -1990,8 +1862,7 @@ requirement that approvers may be tempted to bypass.
 
 ---
 
-### OSPS-QA-04 -  Any additional [subproject][Subproject] [code][Code] [repositories][Repository] produced by the [project][Project] and compiled into a [release][Release] MUST enforce security requirements as applicable to the status and intent of the respective codebase.
- 
+### OSPS-QA-04 - Any additional [subproject][Subproject] [code][Code] [repositories][Repository] produced by the [project][Project] and compiled into a [release][Release] MUST enforce security requirements as applicable to the status and intent of the respective codebase.
 
 
 Ensure that additional code repositories or subprojects produced by the
@@ -2003,9 +1874,7 @@ codebase.
 
 #### OSPS-QA-04.01
 
-**Requirement:**  While active, the [project][Project] documentation MUST contain a list of any
- codebases that are considered [subprojects][Subproject].
- 
+**Requirement:** While active, the [project][Project] documentation MUST contain a list of any codebases that are considered [subprojects][Subproject].
 
 **Recommendation:** 
 Document any additional subproject code repositories produced by the
@@ -2023,10 +1892,7 @@ the status and intent of the respective codebase.
 
 #### OSPS-QA-04.02
 
-**Requirement:**  When the [project][Project] has made a [release][Release] comprising multiple source [code][Code]
- [repositories][Repository], all [subprojects][Subproject] MUST enforce security requirements that
- are as strict or stricter than the primary codebase.
- 
+**Requirement:** When the [project][Project] has made a [release][Release] comprising multiple source [code][Code] [repositories][Repository], all [subprojects][Subproject] MUST enforce security requirements that are as strict or stricter than the primary codebase.
 
 **Recommendation:** 
 Any additional subproject code repositories produced by the project
@@ -2060,8 +1926,7 @@ security issues.
 
 ---
 
-### OSPS-QA-05 -  The [version control system][Version Control System] MUST NOT contain generated executable artifacts.
- 
+### OSPS-QA-05 - The [version control system][Version Control System] MUST NOT contain generated executable artifacts.
 
 
 Reduce the risk of including generated executable artifacts in the
@@ -2073,9 +1938,7 @@ necessary files are stored in the repository.
 
 #### OSPS-QA-05.01
 
-**Requirement:**  While active, the [version control system][Version Control System] MUST NOT contain generated
- executable artifacts.
- 
+**Requirement:** While active, the [version control system][Version Control System] MUST NOT contain generated executable artifacts.
 
 **Recommendation:** 
 Remove generated executable artifacts in the project&#39;s version control
@@ -2095,9 +1958,7 @@ fetched during a specific well-documented pipeline step.
 
 #### OSPS-QA-05.02
 
-**Requirement:**  While active, the [version control system][Version Control System] MUST NOT contain unreviewable
- binary artifacts.
- 
+**Requirement:** While active, the [version control system][Version Control System] MUST NOT contain unreviewable binary artifacts.
 
 **Recommendation:** 
 Do not add any unreviewable binary artifacts to the project&#39;s version
@@ -2128,8 +1989,7 @@ stored in a binary format.
 
 ---
 
-### OSPS-QA-06 -  The [project][Project] MUST use at least one [automated test suite][Automated Test Suite] for the source [code][Code] [repository][Repository].
- 
+### OSPS-QA-06 - The [project][Project] MUST use at least one [automated test suite][Automated Test Suite] for the source [code][Code] [repository][Repository].
 
 
 Ensure that the project uses at least one automated test suite for the
@@ -2140,10 +2000,7 @@ source code repository and clearly documents when and how tests are run.
 
 #### OSPS-QA-06.01
 
-**Requirement:**  Prior to a [commit][Commit] being accepted, the [project][Project]&#39;s [CI/CD pipelines][CI/CD Pipeline] MUST
- run at least one [automated test suite][Automated Test Suite] to ensure the [changes][Change] meet
- expectations.
- 
+**Requirement:** Prior to a [commit][Commit] being accepted, the [project][Project]&#39;s [CI/CD pipelines][CI/CD Pipeline] MUST run at least one [automated test suite][Automated Test Suite] to ensure the [changes][Change] meet expectations.
 
 **Recommendation:** 
 Automated tests should be run prior to every merge into the primary
@@ -2164,9 +2021,7 @@ end-to-end tests.
 
 #### OSPS-QA-06.02
 
-**Requirement:**  While active, [project][Project]&#39;s documentation MUST clearly document when and
- how tests are run.
- 
+**Requirement:** While active, [project][Project]&#39;s documentation MUST clearly document when and how tests are run.
 
 **Recommendation:** 
 Add a section to the contributing documentation that explains how to
@@ -2183,10 +2038,7 @@ interpret the results.
 
 #### OSPS-QA-06.03
 
-**Requirement:**  While active, the [project][Project]&#39;s documentation MUST include a policy that
- all major [changes][Change] to the software produced by the [project][Project] should add
- or update tests of the functionality in an [automated test suite][Automated Test Suite].
- 
+**Requirement:** While active, the [project][Project]&#39;s documentation MUST include a policy that all major [changes][Change] to the software produced by the [project][Project] should add or update tests of the functionality in an [automated test suite][Automated Test Suite].
 
 **Recommendation:** 
 Add a section to the contributing documentation that explains the
@@ -2219,8 +2071,7 @@ constitutes a major change and what tests should be added or updated.
 
 ---
 
-### OSPS-QA-07 -  The [project][Project]&#39;s [version control system][Version Control System] MUST require at least one non-author human approval of [changes][Change] to the [primary branch][Primary Branch].
- 
+### OSPS-QA-07 - The [project][Project]&#39;s [version control system][Version Control System] MUST require at least one non-author human approval of [changes][Change] to the [primary branch][Primary Branch].
 
 
 Ensure that the project&#39;s version control system requires at least one
@@ -2232,10 +2083,7 @@ branch.
 
 #### OSPS-QA-07.01
 
-**Requirement:**  When a [commit][Commit] is made to the [primary branch][Primary Branch], the [project][Project]&#39;s version
- control system MUST require at least one non-author human approval of the
- [changes][Change] before merging.
- 
+**Requirement:** When a [commit][Commit] is made to the [primary branch][Primary Branch], the [project][Project]&#39;s version control system MUST require at least one non-author human approval of the [changes][Change] before merging.
 
 **Recommendation:** 
 Configure the project&#39;s version control system to require at least one
@@ -2274,8 +2122,7 @@ and threats in the software.
 
 
 
-### OSPS-SA-01 -  The [project][Project] documentation MUST provide design documentation demonstrating all actions and actors within the system.
- 
+### OSPS-SA-01 - The [project][Project] documentation MUST provide design documentation demonstrating all actions and actors within the system.
 
 
 Provide an overview of the project&#39;s design and architecture, illustrating
@@ -2288,10 +2135,7 @@ assets.
 
 #### OSPS-SA-01.01
 
-**Requirement:**  When the [project][Project] has made a [release][Release], the [project][Project] documentation MUST
- include design documentation demonstrating all actions and actors
- within the system.
- 
+**Requirement:** When the [project][Project] has made a [release][Release], the [project][Project] documentation MUST include design documentation demonstrating all actions and actors within the system.
 
 **Recommendation:** 
 Include designs in the project documentation that explains the actions
@@ -2326,8 +2170,7 @@ Ensure this is updated for new features or breaking changes.
 
 ---
 
-### OSPS-SA-02 -  The [project][Project] documentation MUST include descriptions of all external software interfaces of the [released software assets][Released Software Asset].
- 
+### OSPS-SA-02 - The [project][Project] documentation MUST include descriptions of all external software interfaces of the [released software assets][Released Software Asset].
 
 
 Provide users and developers with an understanding of how to interact with
@@ -2339,10 +2182,7 @@ to use the software effectively.
 
 #### OSPS-SA-02.01
 
-**Requirement:**  When the [project][Project] has made a [release][Release], the [project][Project] documentation MUST
- include descriptions of all external software interfaces of the
- [released software assets][Released Software Asset].
- 
+**Requirement:** When the [project][Project] has made a [release][Release], the [project][Project] documentation MUST include descriptions of all external software interfaces of the [released software assets][Released Software Asset].
 
 **Recommendation:** 
 Document all software interfaces (APIs) of the released software
@@ -2375,8 +2215,7 @@ Ensure this is updated for new features or breaking changes.
 
 ---
 
-### OSPS-SA-03 -  The [project][Project] MUST assess the security posture of all software assets.
- 
+### OSPS-SA-03 - The [project][Project] MUST assess the security posture of all software assets.
 
 
 Provide project maintainers an understanding of how the software can be
@@ -2388,10 +2227,7 @@ of those threats from occurring.
 
 #### OSPS-SA-03.01
 
-**Requirement:**  When the [project][Project] has made a [release][Release], the [project][Project] MUST perform a
- security assessment to understand the most likely and impactful
- potential security problems that could occur within the software.
- 
+**Requirement:** When the [project][Project] has made a [release][Release], the [project][Project] MUST perform a security assessment to understand the most likely and impactful potential security problems that could occur within the software.
 
 **Recommendation:** 
 Performing a security assessment informs both project members as well
@@ -2412,11 +2248,7 @@ Ensure this is updated for new features or breaking changes.
 
 #### OSPS-SA-03.02
 
-**Requirement:**  When the [project][Project] has made a [release][Release], the [project][Project] MUST perform a threat
- modeling and [attack surface analysis][Attack Surface Analysis] to understand and protect against
- attacks on critical [code][Code] paths, functions, and interactions within the
- system.
- 
+**Requirement:** When the [project][Project] has made a [release][Release], the [project][Project] MUST perform a threat modeling and [attack surface analysis][Attack Surface Analysis] to understand and protect against attacks on critical [code][Code] paths, functions, and interactions within the system.
 
 **Recommendation:** 
 Threat modeling is an activity where the project looks at the
@@ -2465,8 +2297,7 @@ security threats and vulnerabilities in the software.
 
 
 
-### OSPS-VM-01 -  The [project][Project] documentation MUST include a policy for coordinated vulnerability disclosure, with a clear timeframe for response.
- 
+### OSPS-VM-01 - The [project][Project] documentation MUST include a policy for coordinated vulnerability disclosure, with a clear timeframe for response.
 
 
 Establish a process for reporting and addressing vulnerabilities in the
@@ -2478,10 +2309,7 @@ transparently.
 
 #### OSPS-VM-01.01
 
-**Requirement:**  While active, the [project][Project] documentation MUST
- include a policy for [coordinated vulnerability disclosure][Coordinated Vulnerability Disclosure] ([CVD][Coordinated Vulnerability Disclosure]), with a clear
- timeframe for response.
- 
+**Requirement:** While active, the [project][Project] documentation MUST include a policy for [coordinated vulnerability disclosure][Coordinated Vulnerability Disclosure] ([CVD][Coordinated Vulnerability Disclosure]), with a clear timeframe for response.
 
 **Recommendation:** 
 Create a SECURITY.md file at the root of the directory, outlining the
@@ -2517,8 +2345,7 @@ project will respond and address reported issues.
 
 ---
 
-### OSPS-VM-02 -  The [project][Project] MUST publish contacts and process for reporting vulnerabilities.
- 
+### OSPS-VM-02 - The [project][Project] MUST publish contacts and process for reporting vulnerabilities.
 
 
 Reports from researchers and users are an important source for identifying
@@ -2531,9 +2358,7 @@ the report to the project.
 
 #### OSPS-VM-02.01
 
-**Requirement:**  While active, the [project][Project] documentation MUST contain
- security contacts.
- 
+**Requirement:** While active, the [project][Project] documentation MUST contain security contacts.
 
 **Recommendation:** 
 Create a security.md (or similarly-named) file that contains security
@@ -2565,8 +2390,7 @@ contacts for the project.
 
 ---
 
-### OSPS-VM-03 -  The [project][Project] MUST provide a means for reporting security vulnerabilities privately to the security contacts within the [project][Project].
- 
+### OSPS-VM-03 - The [project][Project] MUST provide a means for reporting security vulnerabilities privately to the security contacts within the [project][Project].
 
 
 Security vulnerabilities should not be shared with the public until such
@@ -2578,10 +2402,7 @@ remediations to protect users of the project.
 
 #### OSPS-VM-03.01
 
-**Requirement:**  While active, the [project][Project] documentation MUST
- provide a means for [private vulnerability reporting][Private Vulnerability Reporting] directly to
- the security contacts within the [project][Project].
- 
+**Requirement:** While active, the [project][Project] documentation MUST provide a means for [private vulnerability reporting][Private Vulnerability Reporting] directly to the security contacts within the [project][Project].
 
 **Recommendation:** 
 Provide a means for security researchers to report vulnerabilities
@@ -2612,8 +2433,7 @@ contacts, or other methods.
 
 ---
 
-### OSPS-VM-04 -  The [project][Project] MUST publicly publish data about discovered vulnerabilities.
- 
+### OSPS-VM-04 - The [project][Project] MUST publicly publish data about discovered vulnerabilities.
 
 
 Consumers of the project must be informed about known vulnerabilities
@@ -2624,9 +2444,7 @@ found within the project.
 
 #### OSPS-VM-04.01
 
-**Requirement:**  While active, the [project][Project] documentation MUST
- publicly publish data about discovered vulnerabilities.
- 
+**Requirement:** While active, the [project][Project] documentation MUST publicly publish data about discovered vulnerabilities.
 
 **Recommendation:** 
 Provide information about known vulnerabilities in a predictable
@@ -2645,11 +2463,7 @@ instructions for mitigation or remediation.
 
 #### OSPS-VM-04.02
 
-**Requirement:**  While active, any vulnerabilities in the
- software components not affecting the [project][Project] MUST be accounted for
- in a VEX document, augmenting the vulnerability report with
- non-exploitability details.
- 
+**Requirement:** While active, any vulnerabilities in the software components not affecting the [project][Project] MUST be accounted for in a VEX document, augmenting the vulnerability report with non-exploitability details.
 
 **Recommendation:** 
 Establish a VEX feed communicating the exploitability status of
@@ -2680,8 +2494,7 @@ executed.
 
 ---
 
-### OSPS-VM-05 -  The [project][Project] MUST enforce a policy for addressing [SCA][Software Composition Analysis] findings.
- 
+### OSPS-VM-05 - The [project][Project] MUST enforce a policy for addressing [SCA][Software Composition Analysis] findings.
 
 
 Ensure that the project clearly communicates the threshold for remediation
@@ -2697,10 +2510,7 @@ malicious.
 
 #### OSPS-VM-05.01
 
-**Requirement:**  While active, the [project][Project] documentation MUST include a policy that
- defines a threshold for remediation of [SCA][Software Composition Analysis] findings related to
- vulnerabilities and [licenses][License].
- 
+**Requirement:** While active, the [project][Project] documentation MUST include a policy that defines a threshold for remediation of [SCA][Software Composition Analysis] findings related to vulnerabilities and [licenses][License].
 
 **Recommendation:** 
 Document a policy in the project that defines a threshold for
@@ -2717,9 +2527,7 @@ these findings.
 
 #### OSPS-VM-05.02
 
-**Requirement:**  While active, the [project][Project] documentation MUST include a policy to
- address [SCA][Software Composition Analysis] violations prior to any [release][Release].
- 
+**Requirement:** While active, the [project][Project] documentation MUST include a policy to address [SCA][Software Composition Analysis] violations prior to any [release][Release].
 
 **Recommendation:** 
 Document a policy in the project to address applicable Software
@@ -2735,12 +2543,7 @@ that verify compliance with that policy prior to release.
 
 #### OSPS-VM-05.03
 
-**Requirement:**  While active, all [changes][Change] to the [project][Project]&#39;s codebase MUST be
- automatically evaluated against a documented policy for malicious
- dependencies and [known vulnerabilities][Known Vulnerabilities] in dependencies, then blocked
- in the event of violations, except when declared and suppressed as
- non-exploitable.
- 
+**Requirement:** While active, all [changes][Change] to the [project][Project]&#39;s codebase MUST be automatically evaluated against a documented policy for malicious dependencies and [known vulnerabilities][Known Vulnerabilities] in dependencies, then blocked in the event of violations, except when declared and suppressed as non-exploitable.
 
 **Recommendation:** 
 Create a status check in the project&#39;s version control system that
@@ -2775,9 +2578,7 @@ can be merged.
 
 ---
 
-### OSPS-VM-06 -  The [project][Project] documentation MUST enforce a policy that defines a
- threshold for remediation of SAST findings.
- 
+### OSPS-VM-06 - The [project][Project] documentation MUST enforce a policy that defines a threshold for remediation of SAST findings.
 
 
 Identify and address defects and security weaknesses in the project&#39;s
@@ -2789,9 +2590,7 @@ insecure software.
 
 #### OSPS-VM-06.01
 
-**Requirement:**  While active, the [project][Project] documentation MUST include a policy that
- defines a threshold for remediation of SAST findings.
- 
+**Requirement:** While active, the [project][Project] documentation MUST include a policy that defines a threshold for remediation of SAST findings.
 
 **Recommendation:** 
 Document a policy in the project that defines a threshold for
@@ -2808,11 +2607,7 @@ these findings.
 
 #### OSPS-VM-06.02
 
-**Requirement:**  While active, all [changes][Change] to the [project][Project]&#39;s codebase MUST be
- automatically evaluated against a documented policy for security
- weaknesses and blocked in the event of violations except when declared
- and suppressed as non-exploitable.
- 
+**Requirement:** While active, all [changes][Change] to the [project][Project]&#39;s codebase MUST be automatically evaluated against a documented policy for security weaknesses and blocked in the event of violations except when declared and suppressed as non-exploitable.
 
 **Recommendation:** 
 Create a status check in the project&#39;s version control system that


### PR DESCRIPTION
Fixes the generation script for Windows, where Git will check out files with `\r\n` newlines, which make their way into the YAML content.  `collapseNewlines` previously only stripped `\n`, causing the scripts on Windows to leave `\r` contents which Git would dutifully return to being full newlines when storing.  To re-generate the baseline, I ran the following:



```pwsh

# Check out baseline YAML from the 2025-10-10 release
git checkout e80d0528b75f82cb7aff29df1683e058cf409dc7 baseline

# Run the generator
cd cmd
go run . compile --output ../docs/versions/2025-10-10.md --checklist-output ../docs/versions/2025-10-10-checklist.md
cd ..

# Update docs/versions/2025-10-10.md to add nav metadata and update `Version: devel`
vi docs/versions/2025-10-10.md
# Update docs/versions/2025-10-10-checklist.md to update `Version: devel`
vi docs/versions/2025-10-10-checklist.md

# Undo the staged changes to the baseline YAML
git checkout upstream/main baseline

# Commit the new website contents:
git commit -as
```

As a one-time kludge, the checklist changes as I also removed whitespace from the beginning and end of the YAML strings, which removes trailing newlines from the checklist.  I'm not sure why the checklist didn't have leading newlines as well -- this may be a difference in YAML parsing between Mac or Linux and Windows.

