### PR TITLE
Revise QA-04.01 to only add requirements for projects with multiple repositories

### DIFF
--- a/baseline/OSPS-QA.yaml
+++ b/baseline/OSPS-QA.yaml
@@ -286,9 +286,8 @@ controls:
       and compiled into a release MUST enforce security requirements as
       applicable to the status and intent of the respective codebase.
     objective: |
-      Ensure that additional code repositories or subprojects produced by the
-      project are held to a standard that is clear and appropriate for that
-      codebase.
+      Ensure that all codebases produced by the project are well
+      documented and held to the same security standard.
     guideline-mappings:
       - reference-id: CRA
         entries:
@@ -325,9 +324,10 @@ controls:
     assessment-requirements:
       - id: OSPS-QA-04.01
         text: |
-          Projects with additional subproject repositories MUST document a list
-          of any codebases that are considered subprojects.
+          Projects with multiple repositories MUST document a list of codebases
+          that are part of the project.
         applicability:
+          - Maturity Level 1
           - Maturity Level 2
           - Maturity Level 3
         recommendation: |


### PR DESCRIPTION
As discussed in the 2025-11-25 meeting.



In my opinion, if projects with only a single repository don't need to do anything (e.g. no security-insights or SBOM) to indicate that status, then the assessment is not harmful but maybe not useful.  In particular, it becomes difficult to assess whether an absence of information means that there is are no sub-projects, or that the control has not been followed.  (In general, sub-projects and the scope of "what is a project" is tricky, and I believe we aren't clear enough in our own documentation yet.  Our current definition is "A group of people and resources that coordinate to produce a release.")  I would be \_happy\_ to support more work on allowing projects to define "this is our set of assets" in an affirmatory way, and to require it at a certain maturity level.  Ideally, this would include not just software repositories, but also distribution channels and other resources.



I believe the concern behind QA-04 as a whole is that a level-3 project ("do-important-thing") might choose to put all their less-savory practices in a sub-project (e.g. "dirty-laundry") and then consume that project through a dependency mechanism.  It's not clear to me how relevant that concern is, given that a project might also depend on a third-party or generic library with the same security properties.



A more important property (to me) is being able to affirmatively know that consuming things from the `@babel` NPM prefix are owned by https://github.com/babel/babel (for example).  I don't know if we have a mechanism or control for that today, but (if widely adopted) that seems helpful for distinguishing typoquatting and other supply chain attacks.

