### PR TITLE
Fix external reference mapping formatting

### DIFF
--- a/cmd/template.md
+++ b/cmd/template.md
@@ -115,7 +115,7 @@ For more information on the project and to make contributions, visit the [GitHub
 #### External Framework Mappings
 {{ if  .GuidelineMappings }}
   {{ range .GuidelineMappings }}
-  - **{{ .ReferenceId | addLinks }}**: {{ range $index, $id := .Entries }}{{ if $index }}, {{ end }}{{ $id }}{{ end }}
+  - **{{ .ReferenceId | addLinks }}**: {{ range $index, $entry := .Entries }}{{ if $index }}, {{ end }}{{ $entry.ReferenceId }}{{ end }}
   {{- end }}
 {{ end }}
 

--- a/docs/versions/2025-10-10.md
+++ b/docs/versions/2025-10-10.md
@@ -394,16 +394,16 @@ settings. Passkeys are acceptable for this control.
 #### External Framework Mappings
 
   
-  - **[BPB][Best Practices Badge]**: {CC-G-1 0 }
-  - **[CRA][Cyber Resilience Act]**: {1.2d 0 }, {1.2e 0 }, {1.2f 0 }
-  - **[SSDF][Secure Software Development Framework]**: {PO.3.2 0 }, {PS.1 0 }, {PS.2 0 }
-  - **[CSF][Cybersecurity Framework]**: {PR.A-02 0 }, {PR.A-05 0 }
-  - **[OpenCRE][OpenCRE]**: {486-813 0 }, {124-564 0 }, {347-352 0 }, {333-858 0 }, {152-725 0 }, {201-246 0 }
-  - **PSSCRM**: {G2.6 0 }, {P3.3 0 }, {E1.2 0 }, {E1.3 0 }, {E1.4 0 }, {E3.1 0 }
-  - **[SAMM][Proactive Software Supply Chain Risk Management Framework]**: {Operations -Environment Management -Configuration Hardening Lvl1 0 }
-  - **[PCIDSS][Payment Card Industry Data Security Standard]**: {2.2.1 0 }, {8.2.1 0 }, {8.3.1 0 }
-  - **UKSSCOP**: {2.1 0 }
-  - **[800-161][NIST Special Publication 800-161 - Cybersecurity Supply Chain Risk Management Practices for Systems and Organizations]**: {AC-4(21) 0 }, {AC-17 0 }, {CM-5 0 }, {CM-6 0 }, {IA-2 0 }, {IA-5 0 }, {1.2e 0 }, {1.2f 0 }
+  - **[BPB][Best Practices Badge]**: CC-G-1
+  - **[CRA][Cyber Resilience Act]**: 1.2d, 1.2e, 1.2f
+  - **[SSDF][Secure Software Development Framework]**: PO.3.2, PS.1, PS.2
+  - **[CSF][Cybersecurity Framework]**: PR.A-02, PR.A-05
+  - **[OpenCRE][OpenCRE]**: 486-813, 124-564, 347-352, 333-858, 152-725, 201-246
+  - **PSSCRM**: G2.6, P3.3, E1.2, E1.3, E1.4, E3.1
+  - **[SAMM][Proactive Software Supply Chain Risk Management Framework]**: Operations -Environment Management -Configuration Hardening Lvl1
+  - **[PCIDSS][Payment Card Industry Data Security Standard]**: 2.2.1, 8.2.1, 8.3.1
+  - **UKSSCOP**: 2.1
+  - **[800-161][NIST Special Publication 800-161 - Cybersecurity Supply Chain Risk Management Practices for Systems and Organizations]**: AC-4(21), AC-17, CM-5, CM-6, IA-2, IA-5, 1.2e, 1.2f
 
 
 ---
@@ -440,14 +440,14 @@ additional permissions only when necessary.
 #### External Framework Mappings
 
   
-  - **[CRA][Cyber Resilience Act]**: {1.2f 0 }
-  - **[SSDF][Secure Software Development Framework]**: {PO.2 0 }, {PO.3.2 0 }, {PS.1 0 }, {PS.2 0 }
-  - **[CSF][Cybersecurity Framework]**: {PR.AA-02 0 }, {PR.AA-05 0 }
-  - **[OpenCRE][OpenCRE]**: {486-813 0 }, {124-564 0 }, {802-056 0 }, {368-633 0 }, {152-725 0 }
-  - **PSSCRM**: {P2.3 0 }, {E1.2 0 }, {E3.3 0 }
-  - **[PCIDSS][Payment Card Industry Data Security Standard]**: {2.2.1 0 }
-  - **UKSSCOP**: {2.1 0 }
-  - **[800-161][NIST Special Publication 800-161 - Cybersecurity Supply Chain Risk Management Practices for Systems and Organizations]**: {AC-2 0 }, {AC-3 0 }, {AC-4(21) 0 }, {AC-5 0 }, {AC-6 0 }, {CM-5 0 }, {CM-7 0 }
+  - **[CRA][Cyber Resilience Act]**: 1.2f
+  - **[SSDF][Secure Software Development Framework]**: PO.2, PO.3.2, PS.1, PS.2
+  - **[CSF][Cybersecurity Framework]**: PR.AA-02, PR.AA-05
+  - **[OpenCRE][OpenCRE]**: 486-813, 124-564, 802-056, 368-633, 152-725
+  - **PSSCRM**: P2.3, E1.2, E3.3
+  - **[PCIDSS][Payment Card Industry Data Security Standard]**: 2.2.1
+  - **UKSSCOP**: 2.1
+  - **[800-161][NIST Special Publication 800-161 - Cybersecurity Supply Chain Risk Management Practices for Systems and Organizations]**: AC-2, AC-3, AC-4(21), AC-5, AC-6, CM-5, CM-7
 
 
 ---
@@ -502,15 +502,15 @@ control system to prevent deletion.
 #### External Framework Mappings
 
   
-  - **[CRA][Cyber Resilience Act]**: {1.2f 0 }
-  - **[SSDF][Secure Software Development Framework]**: {PO.3.2 0 }, {PS.1 0 }, {PS.2 0 }
-  - **[CSF][Cybersecurity Framework]**: {PR.A-02 0 }, {PR.A-05 0 }
-  - **[OpenCRE][OpenCRE]**: {486-813 0 }, {124-564 0 }, {152-725 0 }
-  - **Scorecard**: {Branch-Protection 0 }
-  - **PSSCRM**: {P3.2 0 }, {P3.5 0 }, {E1.5 0 }, {E3.1 0 }
-  - **[PCIDSS][Payment Card Industry Data Security Standard]**: {2.2.1 0 }
-  - **UKSSCOP**: {2.1 0 }, {2.2 0 }
-  - **[800-161][NIST Special Publication 800-161 - Cybersecurity Supply Chain Risk Management Practices for Systems and Organizations]**: {AC-3 0 }, {AC-5 0 }, {CM-3 0 }, {CM-3(2) 0 }, {CM-5 0 }
+  - **[CRA][Cyber Resilience Act]**: 1.2f
+  - **[SSDF][Secure Software Development Framework]**: PO.3.2, PS.1, PS.2
+  - **[CSF][Cybersecurity Framework]**: PR.A-02, PR.A-05
+  - **[OpenCRE][OpenCRE]**: 486-813, 124-564, 152-725
+  - **Scorecard**: Branch-Protection
+  - **PSSCRM**: P3.2, P3.5, E1.5, E3.1
+  - **[PCIDSS][Payment Card Industry Data Security Standard]**: 2.2.1
+  - **UKSSCOP**: 2.1, 2.2
+  - **[800-161][NIST Special Publication 800-161 - Cybersecurity Supply Chain Risk Management Practices for Systems and Organizations]**: AC-3, AC-5, CM-3, CM-3(2), CM-5
 
 
 ---
@@ -563,16 +563,16 @@ level. If not, set permissions at the top level of the pipeline.
 #### External Framework Mappings
 
   
-  - **[CRA][Cyber Resilience Act]**: {1.2d 0 }, {1.2e 0 }, {1.2f 0 }
-  - **[SSDF][Secure Software Development Framework]**: {PO.2 0 }, {PO.3.2 0 }, {PS.1 0 }, {PS.2 0 }
-  - **[CSF][Cybersecurity Framework]**: {PR.AA-02 0 }, {PR.AA-05 0 }
-  - **[OpenCRE][OpenCRE]**: {486-813 0 }, {124-564 0 }, {347-507 0 }, {263-284 0 }, {123-124 0 }
-  - **[SLSA][Supply-chain Levels for Software Artifacts]**: {Producer - Choose an appropriate build platform 0 }, {Build platform - Isolation strength - Isolated 0 }
-  - **PSSCRM**: {P3.2 0 }
-  - **[SAMM][Proactive Software Supply Chain Risk Management Framework]**: {Operations -Environment Management -Configuration Hardening Lvl1 0 }
-  - **[PCIDSS][Payment Card Industry Data Security Standard]**: {2.2.1 0 }, {8.2.1 0 }
-  - **UKSSCOP**: {2.1 0 }, {2.2 0 }
-  - **[800-161][NIST Special Publication 800-161 - Cybersecurity Supply Chain Risk Management Practices for Systems and Organizations]**: {AC-3(8) 0 }, {AC-4 0 }, {AC-4(6) 0 }, {AC-6 0 }, {AC-20 0 }, {AC-20(1) 0 }, {CM-5 0 }, {CM-7 0 }
+  - **[CRA][Cyber Resilience Act]**: 1.2d, 1.2e, 1.2f
+  - **[SSDF][Secure Software Development Framework]**: PO.2, PO.3.2, PS.1, PS.2
+  - **[CSF][Cybersecurity Framework]**: PR.AA-02, PR.AA-05
+  - **[OpenCRE][OpenCRE]**: 486-813, 124-564, 347-507, 263-284, 123-124
+  - **[SLSA][Supply-chain Levels for Software Artifacts]**: Producer - Choose an appropriate build platform, Build platform - Isolation strength - Isolated
+  - **PSSCRM**: P3.2
+  - **[SAMM][Proactive Software Supply Chain Risk Management Framework]**: Operations -Environment Management -Configuration Hardening Lvl1
+  - **[PCIDSS][Payment Card Industry Data Security Standard]**: 2.2.1, 8.2.1
+  - **UKSSCOP**: 2.1, 2.2
+  - **[800-161][NIST Special Publication 800-161 - Cybersecurity Supply Chain Risk Management Practices for Systems and Organizations]**: AC-3(8), AC-4, AC-4(6), AC-6, AC-20, AC-20(1), CM-5, CM-7
 
 
 ---
@@ -632,14 +632,14 @@ accessing privileged resources.
 #### External Framework Mappings
 
   
-  - **[CRA][Cyber Resilience Act]**: {1.2f 0 }
-  - **[SSDF][Secure Software Development Framework]**: {PO.3.2 0 }, {PO.5.2 0 }, {PS.1 0 }, {PS.2 0 }
-  - **[CSF][Cybersecurity Framework]**: {PR.AA-02 0 }
-  - **[OpenCRE][OpenCRE]**: {486-813 0 }, {124-564 0 }, {357-352 0 }
-  - **[SLSA][Supply-chain Levels for Software Artifacts]**: {Choose an appropriate build platform 0 }
-  - **PSSCRM**: {P2.3 0 }, {P3.2 0 }, {P3.5 0 }, {E2.4 0 }, {E2.5 0 }, {D2.2 0 }
-  - **[PCIDSS][Payment Card Industry Data Security Standard]**: {2.2.1 0 }, {6.4.1 0 }
-  - **[800-161][NIST Special Publication 800-161 - Cybersecurity Supply Chain Risk Management Practices for Systems and Organizations]**: {AC-3 0 }, {AC-4 0 }, {AC-4(21) 0 }, {CM-5 0 }, {CM-7 0 }, {SI-7 0 }
+  - **[CRA][Cyber Resilience Act]**: 1.2f
+  - **[SSDF][Secure Software Development Framework]**: PO.3.2, PO.5.2, PS.1, PS.2
+  - **[CSF][Cybersecurity Framework]**: PR.AA-02
+  - **[OpenCRE][OpenCRE]**: 486-813, 124-564, 357-352
+  - **[SLSA][Supply-chain Levels for Software Artifacts]**: Choose an appropriate build platform
+  - **PSSCRM**: P2.3, P3.2, P3.5, E2.4, E2.5, D2.2
+  - **[PCIDSS][Payment Card Industry Data Security Standard]**: 2.2.1, 6.4.1
+  - **[800-161][NIST Special Publication 800-161 - Cybersecurity Supply Chain Risk Management Practices for Systems and Organizations]**: AC-3, AC-4, AC-4(21), CM-5, CM-7, SI-7
 
 
 ---
@@ -691,15 +691,15 @@ scheme. Examples include SemVer, CalVer, or git commit id.
 #### External Framework Mappings
 
   
-  - **[BPB][Best Practices Badge]**: {CC-B-5 0 }, {CC-B-6 0 }, {CC-B-7 0 }
-  - **[CRA][Cyber Resilience Act]**: {1.2f 0 }
-  - **[SSDF][Secure Software Development Framework]**: {PO.3.2 0 }, {PS.1 0 }, {PS.2 0 }, {PS.3 0 }
-  - **[OpenCRE][OpenCRE]**: {486-813 0 }, {124-564 0 }
-  - **[SLSA][Supply-chain Levels for Software Artifacts]**: {Follow a consistent build process 0 }, {Provenance generation- Exists, Authentic 0 }
-  - **PSSCRM**: {G1.4 0 }, {E1.2 0 }, {E2.1 0 }, {E2.6 0 }
-  - **[PCIDSS][Payment Card Industry Data Security Standard]**: {6.4.3 0 }
-  - **UKSSCOP**: {3.1 0 }
-  - **[800-161][NIST Special Publication 800-161 - Cybersecurity Supply Chain Risk Management Practices for Systems and Organizations]**: {IA-4 0 }, {SA-15 0 }, {SI-7 0 }, {SR-4 0 }
+  - **[BPB][Best Practices Badge]**: CC-B-5, CC-B-6, CC-B-7
+  - **[CRA][Cyber Resilience Act]**: 1.2f
+  - **[SSDF][Secure Software Development Framework]**: PO.3.2, PS.1, PS.2, PS.3
+  - **[OpenCRE][OpenCRE]**: 486-813, 124-564
+  - **[SLSA][Supply-chain Levels for Software Artifacts]**: Follow a consistent build process, Provenance generation- Exists, Authentic
+  - **PSSCRM**: G1.4, E1.2, E2.1, E2.6
+  - **[PCIDSS][Payment Card Industry Data Security Standard]**: 6.4.3
+  - **UKSSCOP**: 3.1
+  - **[800-161][NIST Special Publication 800-161 - Cybersecurity Supply Chain Risk Management Practices for Systems and Organizations]**: IA-4, SA-15, SI-7, SR-4
 
 
 ---
@@ -754,15 +754,15 @@ channels such as SSH or HTTPS for data transmission.
 #### External Framework Mappings
 
   
-  - **[BPB][Best Practices Badge]**: {B-B-11 0 }
-  - **[CRA][Cyber Resilience Act]**: {1.2d 0 }, {1.2e 0 }, {1.2f 0 }, {1.2i 0 }, {1.2j 0 }, {1.2k 0 }
-  - **[SSDF][Secure Software Development Framework]**: {PO.3.2 0 }, {PO.5.2 0 }, {PS.1 0 }, {PS.2 0 }
-  - **[OpenCRE][OpenCRE]**: {483-813 0 }, {124-564 0 }, {263-184 0 }
-  - **[SLSA][Supply-chain Levels for Software Artifacts]**: {Choose an appropriate build platform 0 }
-  - **PSSCRM**: {E1.1 0 }, {E2.2 0 }, {E2.4 0 }, {E2.5 0 }
-  - **[PCIDSS][Payment Card Industry Data Security Standard]**: {2.2.1 0 }, {2.2.7 0 }, {4.2.1 0 }, {4.2.2 0 }, {6.4.1 0 }, {8.3.2 0 }
-  - **UKSSCOP**: {3.1 0 }
-  - **[800-161][NIST Special Publication 800-161 - Cybersecurity Supply Chain Risk Management Practices for Systems and Organizations]**: {AC-4 0 }, {AC-4(21) 0 }
+  - **[BPB][Best Practices Badge]**: B-B-11
+  - **[CRA][Cyber Resilience Act]**: 1.2d, 1.2e, 1.2f, 1.2i, 1.2j, 1.2k
+  - **[SSDF][Secure Software Development Framework]**: PO.3.2, PO.5.2, PS.1, PS.2
+  - **[OpenCRE][OpenCRE]**: 483-813, 124-564, 263-184
+  - **[SLSA][Supply-chain Levels for Software Artifacts]**: Choose an appropriate build platform
+  - **PSSCRM**: E1.1, E2.2, E2.4, E2.5
+  - **[PCIDSS][Payment Card Industry Data Security Standard]**: 2.2.1, 2.2.7, 4.2.1, 4.2.2, 6.4.1, 8.3.2
+  - **UKSSCOP**: 3.1
+  - **[800-161][NIST Special Publication 800-161 - Cybersecurity Supply Chain Risk Management Practices for Systems and Organizations]**: AC-4, AC-4(21)
 
 
 ---
@@ -801,15 +801,15 @@ such as &#34;## Changelog&#34;.
 #### External Framework Mappings
 
   
-  - **[BPB][Best Practices Badge]**: {CC-B-8 0 }, {CC-B-9 0 }, {Q-B-7 0 }, {A-B-1 0 }, {A-S-1 0 }
-  - **[CRA][Cyber Resilience Act]**: {1.2d 0 }, {1.2f 0 }, {1.2h 0 }, {1.2j 0 }, {1.2l 0 }, {2.5 0 }
-  - **[SSDF][Secure Software Development Framework]**: {PS.1 0 }, {PS.2 0 }, {PS.3 0 }, {PW.1.2 0 }
-  - **[OpenCRE][OpenCRE]**: {483-813 0 }, {068-486 0 }, {124-564 0 }, {757-271 0 }, {347-352 0 }, {263-184 0 }, {208-355 0 }, {745-356 0 }, {732-148 0 }
-  - **[SLSA][Supply-chain Levels for Software Artifacts]**: {Choose an appropriate build platform 0 }, {Follow a consistent build process 0 }, {Build platform - Isolation strength - isolated 0 }
-  - **PSSCRM**: {G1.4 0 }, {E2.1 0 }, {E2.4 0 }, {E2.5 0 }, {E3.1 0 }, {E3.6 0 }
-  - **[PCIDSS][Payment Card Industry Data Security Standard]**: {6.2.1 0 }, {6.4.1 0 }, {6.5.1 0 }, {6.5.2 0 }, {10.2.2 0 }
-  - **UKSSCOP**: {3.1 0 }, {3.5 0 }
-  - **[800-161][NIST Special Publication 800-161 - Cybersecurity Supply Chain Risk Management Practices for Systems and Organizations]**: {AU-2 0 }, {AU-6 0 }, {AU-10 0 }, {CM-5 0 }, {CM-6 0 }, {MA-1 0 }, {MA-8 0 }, {SI-4 0 }, {SI-5 0 }
+  - **[BPB][Best Practices Badge]**: CC-B-8, CC-B-9, Q-B-7, A-B-1, A-S-1
+  - **[CRA][Cyber Resilience Act]**: 1.2d, 1.2f, 1.2h, 1.2j, 1.2l, 2.5
+  - **[SSDF][Secure Software Development Framework]**: PS.1, PS.2, PS.3, PW.1.2
+  - **[OpenCRE][OpenCRE]**: 483-813, 068-486, 124-564, 757-271, 347-352, 263-184, 208-355, 745-356, 732-148
+  - **[SLSA][Supply-chain Levels for Software Artifacts]**: Choose an appropriate build platform, Follow a consistent build process, Build platform - Isolation strength - isolated
+  - **PSSCRM**: G1.4, E2.1, E2.4, E2.5, E3.1, E3.6
+  - **[PCIDSS][Payment Card Industry Data Security Standard]**: 6.2.1, 6.4.1, 6.5.1, 6.5.2, 10.2.2
+  - **UKSSCOP**: 3.1, 3.5
+  - **[800-161][NIST Special Publication 800-161 - Cybersecurity Supply Chain Risk Management Practices for Systems and Organizations]**: AU-2, AU-6, AU-10, CM-5, CM-6, MA-1, MA-8, SI-4, SI-5
 
 
 ---
@@ -847,16 +847,16 @@ system.
 #### External Framework Mappings
 
   
-  - **[BPB][Best Practices Badge]**: {Q-B-2 0 }
-  - **[CRA][Cyber Resilience Act]**: {1.2b 0 }, {1.2d 0 }, {1.2f 0 }, {1.2h 0 }, {1.2j 0 }, {2.1 0 }, {2.2 0 }, {2.3 0 }
-  - **[SSDF][Secure Software Development Framework]**: {PO.3.2 0 }, {PS.1 0 }, {PS.2 0 }
-  - **[OpenCRE][OpenCRE]**: {486-813 0 }, {124-564 0 }, {347-352 0 }, {715-334 0 }
-  - **[SLSA][Supply-chain Levels for Software Artifacts]**: {Isolation strength - isolated 0 }
-  - **PSSCRM**: {P3.1 0 }, {P3.5 0 }, {E2.2 0 }, {E2.3 0 }, {E2.4 0 }, {E2.5 0 }
-  - **[SAMM][Proactive Software Supply Chain Risk Management Framework]**: {Implementation -Secure Build -Build Process Lvl2 0 }
-  - **[PCIDSS][Payment Card Industry Data Security Standard]**: {6.4.3 0 }
-  - **UKSSCOP**: {1.1 0 }, {1.2 0 }
-  - **[800-161][NIST Special Publication 800-161 - Cybersecurity Supply Chain Risk Management Practices for Systems and Organizations]**: {AC-4 0 }, {CM-2 0 }, {CM-7(4) 0 }, {CM-7(5) 0 }, {RA-5 0 }, {SA-15 0 }, {SR-3 0 }
+  - **[BPB][Best Practices Badge]**: Q-B-2
+  - **[CRA][Cyber Resilience Act]**: 1.2b, 1.2d, 1.2f, 1.2h, 1.2j, 2.1, 2.2, 2.3
+  - **[SSDF][Secure Software Development Framework]**: PO.3.2, PS.1, PS.2
+  - **[OpenCRE][OpenCRE]**: 486-813, 124-564, 347-352, 715-334
+  - **[SLSA][Supply-chain Levels for Software Artifacts]**: Isolation strength - isolated
+  - **PSSCRM**: P3.1, P3.5, E2.2, E2.3, E2.4, E2.5
+  - **[SAMM][Proactive Software Supply Chain Risk Management Framework]**: Implementation -Secure Build -Build Process Lvl2
+  - **[PCIDSS][Payment Card Industry Data Security Standard]**: 6.4.3
+  - **UKSSCOP**: 1.1, 1.2
+  - **[800-161][NIST Special Publication 800-161 - Cybersecurity Supply Chain Risk Management Practices for Systems and Organizations]**: AC-4, CM-2, CM-7(4), CM-7(5), RA-5, SA-15, SR-3
 
 
 ---
@@ -891,14 +891,14 @@ hashes of each asset in a signed manifest or metadata file.
 #### External Framework Mappings
 
   
-  - **[SSDF][Secure Software Development Framework]**: {PO.5.2 0 }, {PS.2 0 }, {PS.2.1 0 }, {PW.6.2 0 }
-  - **Scorecard**: {Signed-Releases 0 }
-  - **[SLSA][Supply-chain Levels for Software Artifacts]**: {Distribute provenance - Exists 0 }
-  - **PSSCRM**: {P1.2 0 }, {P3.2 0 }, {P3.3 0 }, {E2.1 0 }, {E2.2 0 }, {E2.6 0 }
-  - **[SAMM][Proactive Software Supply Chain Risk Management Framework]**: {Implementation -Secure Deployment -Deployment Process Lvl3 0 }
-  - **[PCIDSS][Payment Card Industry Data Security Standard]**: {2.2.1 0 }, {2.2.7 0 }, {3.5.1 0 }, {4.2.1 0 }, {4.2.2 0 }, {6.4.1 0 }, {8.3.2 0 }
-  - **UKSSCOP**: {3.1 0 }
-  - **[800-161][NIST Special Publication 800-161 - Cybersecurity Supply Chain Risk Management Practices for Systems and Organizations]**: {AU-10 0 }, {MP-1 0 }, {SA-15 0 }, {SI-7 0 }, {SI-7(14) 0 }
+  - **[SSDF][Secure Software Development Framework]**: PO.5.2, PS.2, PS.2.1, PW.6.2
+  - **Scorecard**: Signed-Releases
+  - **[SLSA][Supply-chain Levels for Software Artifacts]**: Distribute provenance - Exists
+  - **PSSCRM**: P1.2, P3.2, P3.3, E2.1, E2.2, E2.6
+  - **[SAMM][Proactive Software Supply Chain Risk Management Framework]**: Implementation -Secure Deployment -Deployment Process Lvl3
+  - **[PCIDSS][Payment Card Industry Data Security Standard]**: 2.2.1, 2.2.7, 3.5.1, 4.2.1, 4.2.2, 6.4.1, 8.3.2
+  - **UKSSCOP**: 3.1
+  - **[800-161][NIST Special Publication 800-161 - Cybersecurity Supply Chain Risk Management Practices for Systems and Organizations]**: AU-10, MP-1, SA-15, SI-7, SI-7(14)
 
 
 ---
@@ -942,8 +942,8 @@ Document how secrets and credentials are managed and used within the project. Th
 #### External Framework Mappings
 
   
-  - **[BPB][Best Practices Badge]**: {S-B-5 0 }
-  - **[SSDF][Secure Software Development Framework]**: {PO.1.1 0 }, {P0.3.1 0 }, {P0.4.2 0 }, {PO.5.1 0 }, {PW.1.2 0 }, {PW.1.3 0 }, {PW.5.1 0 }
+  - **[BPB][Best Practices Badge]**: S-B-5
+  - **[SSDF][Secure Software Development Framework]**: PO.1.1, P0.3.1, P0.4.2, PO.5.1, PW.1.2, PW.1.3, PW.5.1
 
 
 ---
@@ -995,16 +995,16 @@ available, include highly-visible warnings.
 #### External Framework Mappings
 
   
-  - **[BPB][Best Practices Badge]**: {B-B-1 0 }, {B-B-9 0 }, {B-S-7 0 }, {B-S-9 0 }
-  - **[CRA][Cyber Resilience Act]**: {1.2b 0 }, {1.2j 0 }, {1.2k 0 }
-  - **[SSDF][Secure Software Development Framework]**: {PW.1.2 0 }
-  - **[CSF][Cybersecurity Framework]**: {GV.OC-04 0 }, {GV.OC-05 0 }
-  - **ISO-[18974][OpenChain]**: {4.1.4 0 }
-  - **[OpenCRE][OpenCRE]**: {036-275 0 }
-  - **PSSCRM**: {G5.1 0 }, {E3.5 0 }
-  - **[PCIDSS][Payment Card Industry Data Security Standard]**: {2.1.1 0 }, {2.2.1 0 }, {3.1.1 0 }, {4.1.1 0 }, {5.1.1 0 }, {6.1.1 0 }, {6.2.1 0 }, {7.1.1 0 }, {8.1.1 0 }, {11.1.1 0 }, {12.10.5 0 }
-  - **UKSSCOP**: {4.1 0 }
-  - **[800-161][NIST Special Publication 800-161 - Cybersecurity Supply Chain Risk Management Practices for Systems and Organizations]**: {CM-2 0 }, {PL-2 0 }, {PL-8 0 }, {SA-15 0 }
+  - **[BPB][Best Practices Badge]**: B-B-1, B-B-9, B-S-7, B-S-9
+  - **[CRA][Cyber Resilience Act]**: 1.2b, 1.2j, 1.2k
+  - **[SSDF][Secure Software Development Framework]**: PW.1.2
+  - **[CSF][Cybersecurity Framework]**: GV.OC-04, GV.OC-05
+  - **ISO-[18974][OpenChain]**: 4.1.4
+  - **[OpenCRE][OpenCRE]**: 036-275
+  - **PSSCRM**: G5.1, E3.5
+  - **[PCIDSS][Payment Card Industry Data Security Standard]**: 2.1.1, 2.2.1, 3.1.1, 4.1.1, 5.1.1, 6.1.1, 6.2.1, 7.1.1, 8.1.1, 11.1.1, 12.10.5
+  - **UKSSCOP**: 4.1
+  - **[800-161][NIST Special Publication 800-161 - Cybersecurity Supply Chain Risk Management Practices for Systems and Organizations]**: CM-2, PL-2, PL-8, SA-15
 
 
 ---
@@ -1043,15 +1043,15 @@ sets expectations for how defects will be triaged and resolved.
 #### External Framework Mappings
 
   
-  - **[BPB][Best Practices Badge]**: {B-B-3 0 }, {R-B-1&#43; 0 }, {R-B-1 0 }, {R-B-2 0 }, {R-S-2 0 }
-  - **[CRA][Cyber Resilience Act]**: {1.2c 0 }, {1.2l 0 }, {2.1 0 }, {2.2 0 }, {2.5 0 }, {2.6 0 }
-  - **[SSDF][Secure Software Development Framework]**: {PW.1.2 0 }, {RV.1.1 0 }, {RV.2.1 0 }, {RV.1.2 0 }
-  - **[CSF][Cybersecurity Framework]**: {RS.MA-02 0 }, {GV.RM-05 0 }
-  - **ISO-[18974][OpenChain]**: {4.2.1 0 }
-  - **[SAMM][Proactive Software Supply Chain Risk Management Framework]**: {Implementation -Defect Management -Defect Tracking Lvl1 0 }, {Implementation -Defect Management -Defect Tracking Lvl2 0 }
-  - **[PCIDSS][Payment Card Industry Data Security Standard]**: {6.3.2 0 }, {6.3.3 0 }, {6.5.1 0 }, {6.5.2 0 }, {12.10.2 0 }
-  - **UKSSCOP**: {1.1 0 }, {1.3 0 }
-  - **[800-161][NIST Special Publication 800-161 - Cybersecurity Supply Chain Risk Management Practices for Systems and Organizations]**: {IR-6 0 }, {SI-4 0 }, {SI-5 0 }
+  - **[BPB][Best Practices Badge]**: B-B-3, R-B-1&#43;, R-B-1, R-B-2, R-S-2
+  - **[CRA][Cyber Resilience Act]**: 1.2c, 1.2l, 2.1, 2.2, 2.5, 2.6
+  - **[SSDF][Secure Software Development Framework]**: PW.1.2, RV.1.1, RV.2.1, RV.1.2
+  - **[CSF][Cybersecurity Framework]**: RS.MA-02, GV.RM-05
+  - **ISO-[18974][OpenChain]**: 4.2.1
+  - **[SAMM][Proactive Software Supply Chain Risk Management Framework]**: Implementation -Defect Management -Defect Tracking Lvl1, Implementation -Defect Management -Defect Tracking Lvl2
+  - **[PCIDSS][Payment Card Industry Data Security Standard]**: 6.3.2, 6.3.3, 6.5.1, 6.5.2, 12.10.2
+  - **UKSSCOP**: 1.1, 1.3
+  - **[800-161][NIST Special Publication 800-161 - Cybersecurity Supply Chain Risk Management Practices for Systems and Organizations]**: IR-6, SI-4, SI-5
 
 
 ---
@@ -1109,14 +1109,14 @@ integrity of the software.
 #### External Framework Mappings
 
   
-  - **[BPB][Best Practices Badge]**: {CC-B-8 0 }
-  - **[CRA][Cyber Resilience Act]**: {1.2d 0 }
-  - **[SSDF][Secure Software Development Framework]**: {PO.4.2 0 }, {PS.2 0 }, {PS.2.1 0 }, {PS.3.1 0 }, {RV.1.3 0 }
-  - **[OpenCRE][OpenCRE]**: {171-222 0 }
-  - **PSSCRM**: {G1.3 0 }, {G2.5 0 }, {P1.2 0 }, {P3.1 0 }, {P3.2 0 }, {P3.3 0 }, {E2.6 0 }
-  - **[PCIDSS][Payment Card Industry Data Security Standard]**: {3.1.1 0 }, {3.5.1 0 }, {4.1.1 0 }, {5.1.1 0 }, {6.1.1 0 }, {6.2.1 0 }, {7.1.1 0 }, {8.1.1 0 }, {11.1.1 0 }
-  - **UKSSCOP**: {3.1 0 }
-  - **[800-161][NIST Special Publication 800-161 - Cybersecurity Supply Chain Risk Management Practices for Systems and Organizations]**: {CM-2 0 }, {IR-1 0 }, {MP-1 0 }, {SA-15 0 }, {SI-7 0 }, {SI-7(14) 0 }
+  - **[BPB][Best Practices Badge]**: CC-B-8
+  - **[CRA][Cyber Resilience Act]**: 1.2d
+  - **[SSDF][Secure Software Development Framework]**: PO.4.2, PS.2, PS.2.1, PS.3.1, RV.1.3
+  - **[OpenCRE][OpenCRE]**: 171-222
+  - **PSSCRM**: G1.3, G2.5, P1.2, P3.1, P3.2, P3.3, E2.6
+  - **[PCIDSS][Payment Card Industry Data Security Standard]**: 3.1.1, 3.5.1, 4.1.1, 5.1.1, 6.1.1, 6.2.1, 7.1.1, 8.1.1, 11.1.1
+  - **UKSSCOP**: 3.1
+  - **[800-161][NIST Special Publication 800-161 - Cybersecurity Supply Chain Risk Management Practices for Systems and Organizations]**: CM-2, IR-1, MP-1, SA-15, SI-7, SI-7(14)
 
 
 ---
@@ -1155,14 +1155,14 @@ any relevant policies or procedures for obtaining support.
 #### External Framework Mappings
 
   
-  - **[BPB][Best Practices Badge]**: {R-B-3 0 }
-  - **[SSDF][Secure Software Development Framework]**: {PO.4.2 0 }, {PS.3.1 0 }, {RV.1.3 0 }
-  - **ISO-[18974][OpenChain]**: {4.1 0 }, {4.3.1 0 }
-  - **PSSCRM**: {E1.6 0 }
-  - **[SAMM][Proactive Software Supply Chain Risk Management Framework]**: {Operations -Operational Management -System Decommissioning -Legacy Management Lvl1 0 }
-  - **[PCIDSS][Payment Card Industry Data Security Standard]**: {2.1.1 0 }, {3.1.1 0 }, {3.2.1 0 }, {4.1.1 0 }, {5.1.1 0 }, {6.1.1 0 }, {6.3.3 0 }, {7.1.1 0 }, {8.1.1 0 }, {11.1.1 0 }
-  - **UKSSCOP**: {4.1 0 }, {4.2 0 }
-  - **[800-161][NIST Special Publication 800-161 - Cybersecurity Supply Chain Risk Management Practices for Systems and Organizations]**: {PL-1 0 }, {PL-2 0 }, {SI-4 0 }
+  - **[BPB][Best Practices Badge]**: R-B-3
+  - **[SSDF][Secure Software Development Framework]**: PO.4.2, PS.3.1, RV.1.3
+  - **ISO-[18974][OpenChain]**: 4.1, 4.3.1
+  - **PSSCRM**: E1.6
+  - **[SAMM][Proactive Software Supply Chain Risk Management Framework]**: Operations -Operational Management -System Decommissioning -Legacy Management Lvl1
+  - **[PCIDSS][Payment Card Industry Data Security Standard]**: 2.1.1, 3.1.1, 3.2.1, 4.1.1, 5.1.1, 6.1.1, 6.3.3, 7.1.1, 8.1.1, 11.1.1
+  - **UKSSCOP**: 4.1, 4.2
+  - **[800-161][NIST Special Publication 800-161 - Cybersecurity Supply Chain Risk Management Practices for Systems and Organizations]**: PL-1, PL-2, SI-4
 
 
 ---
@@ -1197,14 +1197,14 @@ explaining the project&#39;s policy for security updates.
 #### External Framework Mappings
 
   
-  - **[CRA][Cyber Resilience Act]**: {1.2c 0 }, {2.6 0 }
-  - **ISO-[18974][OpenChain]**: {4.1.1 0 }, {4.3.1 0 }
-  - **[OpenCRE][OpenCRE]**: {673-475 0 }, {053-751 0 }
-  - **PSSCRM**: {E1.6 0 }
-  - **[SAMM][Proactive Software Supply Chain Risk Management Framework]**: {Operations -Operational Management -System Decommissioning -Legacy Management Lvl1 0 }, {Operations -Operational Management -System Decommissioning -Legacy Management Lvl2 0 }
-  - **[PCIDSS][Payment Card Industry Data Security Standard]**: {3.1.1 0 }, {3.2.1 0 }, {4.1.1 0 }, {5.1.1 0 }, {6.1.1 0 }, {6.3.2 0 }, {7.1.1 0 }, {8.1.1 0 }, {11.1.1 0 }
-  - **UKSSCOP**: {3.5 0 }, {4.1 0 }
-  - **[800-161][NIST Special Publication 800-161 - Cybersecurity Supply Chain Risk Management Practices for Systems and Organizations]**: {PL-1 0 }, {PL-2 0 }, {SI-4 0 }, {SI-5 0 }
+  - **[CRA][Cyber Resilience Act]**: 1.2c, 2.6
+  - **ISO-[18974][OpenChain]**: 4.1.1, 4.3.1
+  - **[OpenCRE][OpenCRE]**: 673-475, 053-751
+  - **PSSCRM**: E1.6
+  - **[SAMM][Proactive Software Supply Chain Risk Management Framework]**: Operations -Operational Management -System Decommissioning -Legacy Management Lvl1, Operations -Operational Management -System Decommissioning -Legacy Management Lvl2
+  - **[PCIDSS][Payment Card Industry Data Security Standard]**: 3.1.1, 3.2.1, 4.1.1, 5.1.1, 6.1.1, 6.3.2, 7.1.1, 8.1.1, 11.1.1
+  - **UKSSCOP**: 3.5, 4.1
+  - **[800-161][NIST Special Publication 800-161 - Cybersecurity Supply Chain Risk Management Practices for Systems and Organizations]**: PL-1, PL-2, SI-4, SI-5
 
 
 ---
@@ -1240,15 +1240,15 @@ as the source code repository, project website, or other channel.
 #### External Framework Mappings
 
   
-  - **[BPB][Best Practices Badge]**: {A-S-1 0 }
-  - **[CRA][Cyber Resilience Act]**: {2.1 0 }
-  - **[OpenCRE][OpenCRE]**: {613-286 0 }, {053-751 0 }
-  - **Scorecard**: {Pinned-Dependencies 0 }
-  - **PSSCRM**: {G1.4 0 }, {G2.4 0 }, {P3.1 0 }, {P3.2 0 }, {P3.4 0 }
-  - **[SAMM][Proactive Software Supply Chain Risk Management Framework]**: {Design -Security Requirements -Supplier Security Lvl2 0 }
-  - **[PCIDSS][Payment Card Industry Data Security Standard]**: {2.1.1 0 }, {3.1.1 0 }, {4.1.1 0 }, {5.1.1 0 }, {6.1.1 0 }, {6.3.2 0 }, {6.4.3 0 }, {7.1.1 0 }, {8.1.1 0 }, {11.1.1 0 }, {12.5.2 0 }
-  - **UKSSCOP**: {1.2 0 }, {3.3 0 }
-  - **[800-161][NIST Special Publication 800-161 - Cybersecurity Supply Chain Risk Management Practices for Systems and Organizations]**: {CA-7 0 }, {CM-7(5) 0 }, {CM-8 0 }, {PM-30 0 }, {RA-3(1) 0 }, {SA-11 0 }, {SI-4 0 }, {SR-3 0 }, {SR-5 0 }, {SR-6 0 }, {SR-7 0 }
+  - **[BPB][Best Practices Badge]**: A-S-1
+  - **[CRA][Cyber Resilience Act]**: 2.1
+  - **[OpenCRE][OpenCRE]**: 613-286, 053-751
+  - **Scorecard**: Pinned-Dependencies
+  - **PSSCRM**: G1.4, G2.4, P3.1, P3.2, P3.4
+  - **[SAMM][Proactive Software Supply Chain Risk Management Framework]**: Design -Security Requirements -Supplier Security Lvl2
+  - **[PCIDSS][Payment Card Industry Data Security Standard]**: 2.1.1, 3.1.1, 4.1.1, 5.1.1, 6.1.1, 6.3.2, 6.4.3, 7.1.1, 8.1.1, 11.1.1, 12.5.2
+  - **UKSSCOP**: 1.2, 3.3
+  - **[800-161][NIST Special Publication 800-161 - Cybersecurity Supply Chain Risk Management Practices for Systems and Organizations]**: CA-7, CM-7(5), CM-8, PM-30, RA-3(1), SA-11, SI-4, SR-3, SR-5, SR-6, SR-7
 
 
 ---
@@ -1316,11 +1316,11 @@ the source code repository of the project.
 #### External Framework Mappings
 
   
-  - **[BPB][Best Practices Badge]**: {B-S-3 0 }, {B-S-4 0 }
-  - **[OpenCRE][OpenCRE]**: {013-021 0 }
-  - **PSSCRM**: {G2.3 0 }, {E3.1 0 }, {E3.3 0 }
-  - **[PCIDSS][Payment Card Industry Data Security Standard]**: {2.1.2 0 }, {3.1.1 0 }, {3.1.2 0 }, {4.1.1 0 }, {4.1.2 0 }, {5.1.1 0 }, {5.1.2 0 }, {6.1.1 0 }, {6.1.2 0 }, {6.5.4 0 }, {7.1.1 0 }, {7.1.2 0 }, {8.1.1 0 }, {8.1.2 0 }, {11.1.1 0 }, {11.1.2 0 }, {12.1.3 0 }, {12.5.2 0 }
-  - **[800-161][NIST Special Publication 800-161 - Cybersecurity Supply Chain Risk Management Practices for Systems and Organizations]**: {AC-2 0 }, {AC-3 0 }, {IA-2 0 }, {PL-1 0 }, {PL-4 0 }, {PM-30 0 }
+  - **[BPB][Best Practices Badge]**: B-S-3, B-S-4
+  - **[OpenCRE][OpenCRE]**: 013-021
+  - **PSSCRM**: G2.3, E3.1, E3.3
+  - **[PCIDSS][Payment Card Industry Data Security Standard]**: 2.1.2, 3.1.1, 3.1.2, 4.1.1, 4.1.2, 5.1.1, 5.1.2, 6.1.1, 6.1.2, 6.5.4, 7.1.1, 7.1.2, 8.1.1, 8.1.2, 11.1.1, 11.1.2, 12.1.3, 12.5.2
+  - **[800-161][NIST Special Publication 800-161 - Cybersecurity Supply Chain Risk Management Practices for Systems and Organizations]**: AC-2, AC-3, IA-2, PL-1, PL-4, PM-30
 
 
 ---
@@ -1357,11 +1357,11 @@ to facilitate open communication and feedback.
 #### External Framework Mappings
 
   
-  - **[BPB][Best Practices Badge]**: {B-B-3 0 }, {B-B-12 0 }
-  - **[CRA][Cyber Resilience Act]**: {1.2l 0 }, {2.3 0 }, {2.4 0 }, {2.6 0 }
-  - **[SSDF][Secure Software Development Framework]**: {PS.3 0 }, {PW.1.2 0 }
-  - **[PCIDSS][Payment Card Industry Data Security Standard]**: {12.5.2 0 }
-  - **[800-161][NIST Special Publication 800-161 - Cybersecurity Supply Chain Risk Management Practices for Systems and Organizations]**: {AC-21 0 }, {AU-6 0 }, {PL-1 0 }
+  - **[BPB][Best Practices Badge]**: B-B-3, B-B-12
+  - **[CRA][Cyber Resilience Act]**: 1.2l, 2.3, 2.4, 2.6
+  - **[SSDF][Secure Software Development Framework]**: PS.3, PW.1.2
+  - **[PCIDSS][Payment Card Industry Data Security Standard]**: 12.5.2
+  - **[800-161][NIST Special Publication 800-161 - Cybersecurity Supply Chain Risk Management Practices for Systems and Organizations]**: AC-21, AU-6, PL-1
 
 
 ---
@@ -1417,13 +1417,13 @@ this guide is the source of truth for both contributors and approvers.
 #### External Framework Mappings
 
   
-  - **[BPB][Best Practices Badge]**: {B-B-4 0 }, {B-S-3 0 }, {B-B-4&#43; 0 }, {R-B-1 0 }, {Q-G-2 0 }
-  - **[CRA][Cyber Resilience Act]**: {1.2l 0 }, {2.4 0 }
-  - **[SSDF][Secure Software Development Framework]**: {PW.1.2 0 }
-  - **ISO-[18974][OpenChain]**: {4.1.2 0 }
-  - **PSSCRM**: {G2.4 0 }, {P2.2 0 }
-  - **[PCIDSS][Payment Card Industry Data Security Standard]**: {2.1.1 0 }, {6.5.4 0 }, {8.2.1 0 }, {12.5.2 0 }
-  - **[800-161][NIST Special Publication 800-161 - Cybersecurity Supply Chain Risk Management Practices for Systems and Organizations]**: {AC-3 0 }, {AC-20 0 }, {PL-1 0 }
+  - **[BPB][Best Practices Badge]**: B-B-4, B-S-3, B-B-4&#43;, R-B-1, Q-G-2
+  - **[CRA][Cyber Resilience Act]**: 1.2l, 2.4
+  - **[SSDF][Secure Software Development Framework]**: PW.1.2
+  - **ISO-[18974][OpenChain]**: 4.1.2
+  - **PSSCRM**: G2.4, P2.2
+  - **[PCIDSS][Payment Card Industry Data Security Standard]**: 2.1.1, 6.5.4, 8.2.1, 12.5.2
+  - **[800-161][NIST Special Publication 800-161 - Cybersecurity Supply Chain Risk Management Practices for Systems and Organizations]**: AC-3, AC-20, PL-1
 
 
 ---
@@ -1459,15 +1459,15 @@ contributor&#39;s association with a known trusted organization.
 #### External Framework Mappings
 
   
-  - **[BPB][Best Practices Badge]**: {B-B-5 0 }, {B-S-3 0 }, {B-B-4&#43; 0 }, {Q-G-2 0 }
-  - **[CRA][Cyber Resilience Act]**: {1.2d 0 }, {1.2l 0 }, {2.1 0 }, {2.2 0 }, {2.5 0 }, {2.6 0 }
-  - **[SSDF][Secure Software Development Framework]**: {PO.2 0 }, {PO.3.2 0 }
-  - **[CSF][Cybersecurity Framework]**: {PR.AA-02 0 }, {PR.AA-05 0 }
-  - **[OpenCRE][OpenCRE]**: {123-124 0 }, {152-725 0 }
-  - **ISO-[18974][OpenChain]**: {4.1.2 0 }
-  - **PSSCRM**: {E3.1 0 }, {E3.3 0 }
-  - **[PCIDSS][Payment Card Industry Data Security Standard]**: {2.1.1 0 }, {6.5.4 0 }, {8.2.1 0 }, {8.2.2 0 }
-  - **[800-161][NIST Special Publication 800-161 - Cybersecurity Supply Chain Risk Management Practices for Systems and Organizations]**: {AC-2 0 }, {AC-3 0 }, {AC-4(21) 0 }, {AC-5 0 }, {AC-6 0 }, {AC-20 0 }, {CM-7 0 }, {IR-4(6) 0 }, {PM-30 0 }, {SI-4 0 }
+  - **[BPB][Best Practices Badge]**: B-B-5, B-S-3, B-B-4&#43;, Q-G-2
+  - **[CRA][Cyber Resilience Act]**: 1.2d, 1.2l, 2.1, 2.2, 2.5, 2.6
+  - **[SSDF][Secure Software Development Framework]**: PO.2, PO.3.2
+  - **[CSF][Cybersecurity Framework]**: PR.AA-02, PR.AA-05
+  - **[OpenCRE][OpenCRE]**: 123-124, 152-725
+  - **ISO-[18974][OpenChain]**: 4.1.2
+  - **PSSCRM**: E3.1, E3.3
+  - **[PCIDSS][Payment Card Industry Data Security Standard]**: 2.1.1, 6.5.4, 8.2.1, 8.2.2
+  - **[800-161][NIST Special Publication 800-161 - Cybersecurity Supply Chain Risk Management Practices for Systems and Organizations]**: AC-2, AC-3, AC-4(21), AC-5, AC-6, AC-20, CM-7, IR-4(6), PM-30, SI-4
 
 
 ---
@@ -1525,12 +1525,12 @@ requirement.
 #### External Framework Mappings
 
   
-  - **[BPB][Best Practices Badge]**: {B-S-1 0 }
-  - **[CRA][Cyber Resilience Act]**: {1.2b 0 }, {1.2f 0 }
-  - **[SSDF][Secure Software Development Framework]**: {PO.3.2 0 }, {PS.1 0 }, {PW.1.2 0 }, {PW.2.1 0 }
-  - **PSSCRM**: {E3.1 0 }
-  - **[PCIDSS][Payment Card Industry Data Security Standard]**: {12.8.5 0 }
-  - **[800-161][NIST Special Publication 800-161 - Cybersecurity Supply Chain Risk Management Practices for Systems and Organizations]**: {PL-4 0 }
+  - **[BPB][Best Practices Badge]**: B-S-1
+  - **[CRA][Cyber Resilience Act]**: 1.2b, 1.2f
+  - **[SSDF][Secure Software Development Framework]**: PO.3.2, PS.1, PW.1.2, PW.2.1
+  - **PSSCRM**: E3.1
+  - **[PCIDSS][Payment Card Industry Data Security Standard]**: 12.8.5
+  - **[800-161][NIST Special Publication 800-161 - Cybersecurity Supply Chain Risk Management Practices for Systems and Organizations]**: PL-4
 
 
 ---
@@ -1593,14 +1593,14 @@ released software assets may be different than the source code.
 #### External Framework Mappings
 
   
-  - **[BPB][Best Practices Badge]**: {B-B-6 0 }, {B-B-7 0 }
-  - **[CRA][Cyber Resilience Act]**: {1.2b 0 }
-  - **[SSDF][Secure Software Development Framework]**: {PO.3.2 0 }
-  - **[CSF][Cybersecurity Framework]**: {GV.OC-03 0 }
-  - **Scorecard**: {License 0 }
-  - **PSSCRM**: {G1.2 0 }
-  - **[PCIDSS][Payment Card Industry Data Security Standard]**: {3.2.1 0 }
-  - **[800-161][NIST Special Publication 800-161 - Cybersecurity Supply Chain Risk Management Practices for Systems and Organizations]**: {PL-4 0 }
+  - **[BPB][Best Practices Badge]**: B-B-6, B-B-7
+  - **[CRA][Cyber Resilience Act]**: 1.2b
+  - **[SSDF][Secure Software Development Framework]**: PO.3.2
+  - **[CSF][Cybersecurity Framework]**: GV.OC-03
+  - **Scorecard**: License
+  - **PSSCRM**: G1.2
+  - **[PCIDSS][Payment Card Industry Data Security Standard]**: 3.2.1
+  - **[800-161][NIST Special Publication 800-161 - Cybersecurity Supply Chain Risk Management Practices for Systems and Organizations]**: PL-4
 
 
 ---
@@ -1659,13 +1659,13 @@ includes the license file.
 #### External Framework Mappings
 
   
-  - **[BPB][Best Practices Badge]**: {B-B-8 0 }
-  - **[CRA][Cyber Resilience Act]**: {1.2b 0 }
-  - **[SSDF][Secure Software Development Framework]**: {PO.3.2 0 }
-  - **Scorecard**: {License 0 }
-  - **PSSCRM**: {G1.2 0 }
-  - **[PCIDSS][Payment Card Industry Data Security Standard]**: {3.2.1 0 }
-  - **[800-161][NIST Special Publication 800-161 - Cybersecurity Supply Chain Risk Management Practices for Systems and Organizations]**: {PL-4 0 }
+  - **[BPB][Best Practices Badge]**: B-B-8
+  - **[CRA][Cyber Resilience Act]**: 1.2b
+  - **[SSDF][Secure Software Development Framework]**: PO.3.2
+  - **Scorecard**: License
+  - **PSSCRM**: G1.2
+  - **[PCIDSS][Payment Card Industry Data Security Standard]**: 3.2.1
+  - **[800-161][NIST Special Publication 800-161 - Cybersecurity Supply Chain Risk Management Practices for Systems and Organizations]**: PL-4
 
 
 ---
@@ -1736,17 +1736,17 @@ in a way that would obscure the author of any commits.
 #### External Framework Mappings
 
   
-  - **[BPB][Best Practices Badge]**: {CC-B-1 0 }, {CC-B-2 0 }, {CC-B-3 0 }, {R-B-5 0 }
-  - **[CRA][Cyber Resilience Act]**: {1.2b 0 }, {1.2f 0 }, {1.2j 0 }
-  - **[SSDF][Secure Software Development Framework]**: {PS.1 0 }, {PS.2 0 }, {PS.3 0 }, {PW.1.2 0 }, {PW.2.1 0 }
-  - **[OpenCRE][OpenCRE]**: {486-813 0 }, {124-564 0 }, {757-271 0 }
-  - **[CSF][Cybersecurity Framework]**: {ID.AM-02 0 }, {ID.RA-01 0 }, {ID.RA-08 0 }
-  - **ISO-[18974][OpenChain]**: {4.1.4 0 }
-  - **[SLSA][Supply-chain Levels for Software Artifacts]**: {Build platform - isolation strength - Isolated 0 }
-  - **PSSCRM**: {P3.5 0 }, {E2.2 0 }
-  - **[SAMM][Proactive Software Supply Chain Risk Management Framework]**: {Implementation -Secure Build -Build Process Lvl1 0 }
-  - **[PCIDSS][Payment Card Industry Data Security Standard]**: {2.1.1 0 }, {6.2.1 0 }, {6.5.1 0 }, {6.5.2 0 }
-  - **[800-161][NIST Special Publication 800-161 - Cybersecurity Supply Chain Risk Management Practices for Systems and Organizations]**: {RA-5 0 }, {SA-11 0 }, {SA-15 0 }
+  - **[BPB][Best Practices Badge]**: CC-B-1, CC-B-2, CC-B-3, R-B-5
+  - **[CRA][Cyber Resilience Act]**: 1.2b, 1.2f, 1.2j
+  - **[SSDF][Secure Software Development Framework]**: PS.1, PS.2, PS.3, PW.1.2, PW.2.1
+  - **[OpenCRE][OpenCRE]**: 486-813, 124-564, 757-271
+  - **[CSF][Cybersecurity Framework]**: ID.AM-02, ID.RA-01, ID.RA-08
+  - **ISO-[18974][OpenChain]**: 4.1.4
+  - **[SLSA][Supply-chain Levels for Software Artifacts]**: Build platform - isolation strength - Isolated
+  - **PSSCRM**: P3.5, E2.2
+  - **[SAMM][Proactive Software Supply Chain Risk Management Framework]**: Implementation -Secure Build -Build Process Lvl1
+  - **[PCIDSS][Payment Card Industry Data Security Standard]**: 2.1.1, 6.2.1, 6.5.1, 6.5.2
+  - **[800-161][NIST Special Publication 800-161 - Cybersecurity Supply Chain Risk Management Practices for Systems and Organizations]**: RA-5, SA-11, SA-15
 
 
 ---
@@ -1800,17 +1800,17 @@ environment.
 #### External Framework Mappings
 
   
-  - **[BPB][Best Practices Badge]**: {Q-S-8 0 }, {Q-S-9 0 }
-  - **[CRA][Cyber Resilience Act]**: {2.1 0 }, {2.2 0 }, {2.3 0 }
-  - **[SSDF][Secure Software Development Framework]**: {PO.3.3 0 }, {PS.1 0 }, {PS.2 0 }, {PS.3.2 0 }, {PW.4 0 }
-  - **[CSF][Cybersecurity Framework]**: {ID.AM.01 0 }, {ID.AM-02 0 }
-  - **ISO-[18974][OpenChain]**: {4.1.5 0 }, {4.3.1 0 }
-  - **[OpenCRE][OpenCRE]**: {486-813 0 }, {124-564 0 }, {673-475 0 }, {863-521 0 }, {613-286 0 }
-  - **PSSCRM**: {G1.4 0 }, {G1.5 0 }, {G2.5 0 }, {P3.1 0 }, {P3.2 0 }, {P5.1 0 }, {P5.2 0 }, {E2.1 0 }, {E2.2 0 }
-  - **[SAMM][Proactive Software Supply Chain Risk Management Framework]**: {Implementation -Secure Build -Software Dependencies Lvl1 0 }
-  - **[PCIDSS][Payment Card Industry Data Security Standard]**: {6.3.2 0 }, {6.4.3 0 }, {12.5.1 0 }
-  - **UKSSCOP**: {1.2 0 }
-  - **[800-161][NIST Special Publication 800-161 - Cybersecurity Supply Chain Risk Management Practices for Systems and Organizations]**: {CA-7 0 }, {CM-2 0 }, {CM-8 0 }, {PL-8 0 }, {RA-3(1) 0 }, {RA-5 0 }, {SA-11 0 }, {SA-15 0 }, {SR-3 0 }, {SR-4 0 }
+  - **[BPB][Best Practices Badge]**: Q-S-8, Q-S-9
+  - **[CRA][Cyber Resilience Act]**: 2.1, 2.2, 2.3
+  - **[SSDF][Secure Software Development Framework]**: PO.3.3, PS.1, PS.2, PS.3.2, PW.4
+  - **[CSF][Cybersecurity Framework]**: ID.AM.01, ID.AM-02
+  - **ISO-[18974][OpenChain]**: 4.1.5, 4.3.1
+  - **[OpenCRE][OpenCRE]**: 486-813, 124-564, 673-475, 863-521, 613-286
+  - **PSSCRM**: G1.4, G1.5, G2.5, P3.1, P3.2, P5.1, P5.2, E2.1, E2.2
+  - **[SAMM][Proactive Software Supply Chain Risk Management Framework]**: Implementation -Secure Build -Software Dependencies Lvl1
+  - **[PCIDSS][Payment Card Industry Data Security Standard]**: 6.3.2, 6.4.3, 12.5.1
+  - **UKSSCOP**: 1.2
+  - **[800-161][NIST Special Publication 800-161 - Cybersecurity Supply Chain Risk Management Practices for Systems and Organizations]**: CA-7, CM-2, CM-8, PL-8, RA-3(1), RA-5, SA-11, SA-15, SR-3, SR-4
 
 
 ---
@@ -1849,15 +1849,15 @@ requirement that approvers may be tempted to bypass.
 #### External Framework Mappings
 
   
-  - **[CRA][Cyber Resilience Act]**: {1.2f 0 }, {1.2k 0 }
-  - **[SSDF][Secure Software Development Framework]**: {PO.4.1 0 }, {PS.1 0 }, {PS.2 0 }, {RV.1.2 0 }
-  - **[CSF][Cybersecurity Framework]**: {ID.IM-02 0 }
-  - **ISO-[18974][OpenChain]**: {4.1.5 0 }
-  - **[OpenCRE][OpenCRE]**: {263-184 0 }, {253-452 0 }
-  - **PSSCRM**: {G2.2 0 }, {G5.3 0 }, {G5.4 0 }, {P3.5 0 }, {P4.1 0 }, {P4.2 0 }
-  - **[SAMM][Proactive Software Supply Chain Risk Management Framework]**: {Implementation -Secure Build -Build Process Lvl3 0 }, {Implementation -Secure Build -Software Dependencies Lvl3 0 }, {Verification -Requirements Testing -Control Verification Lvl1 0 }, {Verification -Requirements Testing -Control Verification Lvl2 0 }, {Verification -Requirements Testing -Control Verification Lvl3 0 }
-  - **[PCIDSS][Payment Card Industry Data Security Standard]**: {6.3.1 0 }, {6.3.2 0 }, {6.5.2 0 }
-  - **[800-161][NIST Special Publication 800-161 - Cybersecurity Supply Chain Risk Management Practices for Systems and Organizations]**: {AU-6 0 }, {CM-3 0 }, {CM-6 0 }, {PL-8 0 }, {SA-11 0 }, {SA-15 0 }, {SR-3 0 }
+  - **[CRA][Cyber Resilience Act]**: 1.2f, 1.2k
+  - **[SSDF][Secure Software Development Framework]**: PO.4.1, PS.1, PS.2, RV.1.2
+  - **[CSF][Cybersecurity Framework]**: ID.IM-02
+  - **ISO-[18974][OpenChain]**: 4.1.5
+  - **[OpenCRE][OpenCRE]**: 263-184, 253-452
+  - **PSSCRM**: G2.2, G5.3, G5.4, P3.5, P4.1, P4.2
+  - **[SAMM][Proactive Software Supply Chain Risk Management Framework]**: Implementation -Secure Build -Build Process Lvl3, Implementation -Secure Build -Software Dependencies Lvl3, Verification -Requirements Testing -Control Verification Lvl1, Verification -Requirements Testing -Control Verification Lvl2, Verification -Requirements Testing -Control Verification Lvl3
+  - **[PCIDSS][Payment Card Industry Data Security Standard]**: 6.3.1, 6.3.2, 6.5.2
+  - **[800-161][NIST Special Publication 800-161 - Cybersecurity Supply Chain Risk Management Practices for Systems and Organizations]**: AU-6, CM-3, CM-6, PL-8, SA-11, SA-15, SR-3
 
 
 ---
@@ -1914,14 +1914,14 @@ security issues.
 #### External Framework Mappings
 
   
-  - **[CRA][Cyber Resilience Act]**: {1.2b 0 }, {1.2f 0 }
-  - **[SSDF][Secure Software Development Framework]**: {PO.3.2 0 }, {PO.4.1 0 }, {PS.1 0 }, {PS.2 0 }, {RV.1.2 0 }
-  - **[OpenCRE][OpenCRE]**: {486-813 0 }, {124-564 0 }
-  - **[SLSA][Supply-chain Levels for Software Artifacts]**: {Build platform - isolation strength - Isolated 0 }
-  - **Scorecard**: {Binary-Artifacts 0 }
-  - **PSSCRM**: {G2.2 0 }, {G5.4 0 }
-  - **[PCIDSS][Payment Card Industry Data Security Standard]**: {6.4.2 0 }
-  - **[800-161][NIST Special Publication 800-161 - Cybersecurity Supply Chain Risk Management Practices for Systems and Organizations]**: {PL-8 0 }, {SA-15 0 }
+  - **[CRA][Cyber Resilience Act]**: 1.2b, 1.2f
+  - **[SSDF][Secure Software Development Framework]**: PO.3.2, PO.4.1, PS.1, PS.2, RV.1.2
+  - **[OpenCRE][OpenCRE]**: 486-813, 124-564
+  - **[SLSA][Supply-chain Levels for Software Artifacts]**: Build platform - isolation strength - Isolated
+  - **Scorecard**: Binary-Artifacts
+  - **PSSCRM**: G2.2, G5.4
+  - **[PCIDSS][Payment Card Industry Data Security Standard]**: 6.4.2
+  - **[800-161][NIST Special Publication 800-161 - Cybersecurity Supply Chain Risk Management Practices for Systems and Organizations]**: PL-8, SA-15
 
 
 ---
@@ -1980,11 +1980,11 @@ stored in a binary format.
 #### External Framework Mappings
 
   
-  - **[CRA][Cyber Resilience Act]**: {1.2b 0 }
-  - **[SSDF][Secure Software Development Framework]**: {PS.1 0 }, {PS.2 0 }
-  - **[OpenCRE][OpenCRE]**: {486-813 0 }, {124-564 0 }
-  - **[PCIDSS][Payment Card Industry Data Security Standard]**: {6.4.3 0 }
-  - **[800-161][NIST Special Publication 800-161 - Cybersecurity Supply Chain Risk Management Practices for Systems and Organizations]**: {PL-8 0 }, {SA-15 0 }, {SR-3 0 }
+  - **[CRA][Cyber Resilience Act]**: 1.2b
+  - **[SSDF][Secure Software Development Framework]**: PS.1, PS.2
+  - **[OpenCRE][OpenCRE]**: 486-813, 124-564
+  - **[PCIDSS][Payment Card Industry Data Security Standard]**: 6.4.3
+  - **[800-161][NIST Special Publication 800-161 - Cybersecurity Supply Chain Risk Management Practices for Systems and Organizations]**: PL-8, SA-15, SR-3
 
 
 ---
@@ -2056,17 +2056,17 @@ constitutes a major change and what tests should be added or updated.
 #### External Framework Mappings
 
   
-  - **[BPB][Best Practices Badge]**: {Q-B-4 0 }, {Q-B-8 0 }, {Q-B-9 0 }, {Q-B-10 0 }, {Q-S-2 0 }
-  - **[CRA][Cyber Resilience Act]**: {2.3 0 }
-  - **[SSDF][Secure Software Development Framework]**: {PW.8.2 0 }
-  - **[CSF][Cybersecurity Framework]**: {ID.AM-02 0 }
-  - **ISO-[18974][OpenChain]**: {4.1.5 0 }
-  - **[OpenCRE][OpenCRE]**: {207-435 0 }, {088-377 0 }
-  - **Scorecard**: {CI-Tests 0 }
-  - **PSSCRM**: {P4.1 0 }, {P4.2 0 }, {P4.3 0 }, {P4.4 0 }, {E2.4 0 }, {E2.5 0 }
-  - **[SAMM][Proactive Software Supply Chain Risk Management Framework]**: {Verification-Requirements -Testing -Control Verification Lvl1 0 }, {Verification-Requirements -Testing -Control Verification Lvl2 0 }, {Verification-Requirements -Testing -Control Verification Lvl3 0 }, {Verification -Security Testing -Scalable Baseline Lvl3 0 }
-  - **[PCIDSS][Payment Card Industry Data Security Standard]**: {6.2.3 0 }, {6.3.1 0 }, {6.3.2 0 }, {6.4.2 0 }
-  - **[800-161][NIST Special Publication 800-161 - Cybersecurity Supply Chain Risk Management Practices for Systems and Organizations]**: {SA-11 0 }, {SA-15 0 }, {SR-3 0 }
+  - **[BPB][Best Practices Badge]**: Q-B-4, Q-B-8, Q-B-9, Q-B-10, Q-S-2
+  - **[CRA][Cyber Resilience Act]**: 2.3
+  - **[SSDF][Secure Software Development Framework]**: PW.8.2
+  - **[CSF][Cybersecurity Framework]**: ID.AM-02
+  - **ISO-[18974][OpenChain]**: 4.1.5
+  - **[OpenCRE][OpenCRE]**: 207-435, 088-377
+  - **Scorecard**: CI-Tests
+  - **PSSCRM**: P4.1, P4.2, P4.3, P4.4, E2.4, E2.5
+  - **[SAMM][Proactive Software Supply Chain Risk Management Framework]**: Verification-Requirements -Testing -Control Verification Lvl1, Verification-Requirements -Testing -Control Verification Lvl2, Verification-Requirements -Testing -Control Verification Lvl3, Verification -Security Testing -Scalable Baseline Lvl3
+  - **[PCIDSS][Payment Card Industry Data Security Standard]**: 6.2.3, 6.3.1, 6.3.2, 6.4.2
+  - **[800-161][NIST Special Publication 800-161 - Cybersecurity Supply Chain Risk Management Practices for Systems and Organizations]**: SA-11, SA-15, SR-3
 
 
 ---
@@ -2102,11 +2102,11 @@ be merged.
 #### External Framework Mappings
 
   
-  - **[BPB][Best Practices Badge]**: {B-G-3 0 }
-  - **Scorecard**: {Code-Review 0 }
-  - **PSSCRM**: {G2.4 0 }, {P3.3 0 }, {P3.5 0 }
-  - **[PCIDSS][Payment Card Industry Data Security Standard]**: {6.2.3.1 0 }, {6.4.2 0 }, {6.5.4 0 }
-  - **[800-161][NIST Special Publication 800-161 - Cybersecurity Supply Chain Risk Management Practices for Systems and Organizations]**: {AC-5 0 }, {AU-6 0 }, {PL-8 0 }, {SA-15 0 }, {SR-3 0 }
+  - **[BPB][Best Practices Badge]**: B-G-3
+  - **Scorecard**: Code-Review
+  - **PSSCRM**: G2.4, P3.3, P3.5
+  - **[PCIDSS][Payment Card Industry Data Security Standard]**: 6.2.3.1, 6.4.2, 6.5.4
+  - **[800-161][NIST Special Publication 800-161 - Cybersecurity Supply Chain Risk Management Practices for Systems and Organizations]**: AC-5, AU-6, PL-8, SA-15, SR-3
 
 
 ---
@@ -2156,16 +2156,16 @@ Ensure this is updated for new features or breaking changes.
 #### External Framework Mappings
 
   
-  - **[BPB][Best Practices Badge]**: {B-B-1 0 }, {B-S-7 0 }, {B-S-8 0 }
-  - **[CRA][Cyber Resilience Act]**: {1.2a 0 }, {1.2b 0 }
-  - **[SSDF][Secure Software Development Framework]**: {PO.1 0 }, {PO.2 0 }, {PO.3.2 0 }
-  - **[CSF][Cybersecurity Framework]**: {ID.AM-02 0 }
-  - **[OpenCRE][OpenCRE]**: {155-155 0 }, {326-704 0 }, {068-102 0 }, {036-275 0 }, {162-655 0 }
-  - **PSSCRM**: {G5.1 0 }, {P1.1 0 }, {E3.4 0 }, {E3.7 0 }
-  - **[SAMM][Proactive Software Supply Chain Risk Management Framework]**: {Operations -Operational Management -Data Protection Lvl2 0 }
-  - **[PCIDSS][Payment Card Industry Data Security Standard]**: {2.2.1 0 }, {2.2.3 0 }, {2.2.4 0 }, {2.2.5 0 }, {2.2.6 0 }, {3.1.1 0 }, {4.1.1 0 }, {5.1.1 0 }, {6.1.1 0 }, {6.2.1 0 }, {7.1.1 0 }, {8.1.1 0 }, {11.1.1 0 }, {12.3.1 0 }, {12.5.3 0 }
-  - **UKSSCOP**: {1.4 0 }
-  - **[800-161][NIST Special Publication 800-161 - Cybersecurity Supply Chain Risk Management Practices for Systems and Organizations]**: {CM-2 0 }, {PL-8 0 }, {RA-3 0 }, {SA-15 0 }
+  - **[BPB][Best Practices Badge]**: B-B-1, B-S-7, B-S-8
+  - **[CRA][Cyber Resilience Act]**: 1.2a, 1.2b
+  - **[SSDF][Secure Software Development Framework]**: PO.1, PO.2, PO.3.2
+  - **[CSF][Cybersecurity Framework]**: ID.AM-02
+  - **[OpenCRE][OpenCRE]**: 155-155, 326-704, 068-102, 036-275, 162-655
+  - **PSSCRM**: G5.1, P1.1, E3.4, E3.7
+  - **[SAMM][Proactive Software Supply Chain Risk Management Framework]**: Operations -Operational Management -Data Protection Lvl2
+  - **[PCIDSS][Payment Card Industry Data Security Standard]**: 2.2.1, 2.2.3, 2.2.4, 2.2.5, 2.2.6, 3.1.1, 4.1.1, 5.1.1, 6.1.1, 6.2.1, 7.1.1, 8.1.1, 11.1.1, 12.3.1, 12.5.3
+  - **UKSSCOP**: 1.4
+  - **[800-161][NIST Special Publication 800-161 - Cybersecurity Supply Chain Risk Management Practices for Systems and Organizations]**: CM-2, PL-8, RA-3, SA-15
 
 
 ---
@@ -2202,15 +2202,15 @@ Ensure this is updated for new features or breaking changes.
 #### External Framework Mappings
 
   
-  - **[BPB][Best Practices Badge]**: {B-B-10 0 }, {B-S-7 0 }
-  - **[CRA][Cyber Resilience Act]**: {1.2a 0 }, {1.2b 0 }
-  - **[SSDF][Secure Software Development Framework]**: {PW.1.2 0 }
-  - **[CSF][Cybersecurity Framework]**: {GV.OC-05 0 }, {ID.AM-01 0 }
-  - **ISO-[18974][OpenChain]**: {4.1.4 0 }
-  - **[OpenCRE][OpenCRE]**: {155-155 0 }, {068-102 0 }, {072-713 0 }, {820-878 0 }
-  - **PSSCRM**: {E3.4 0 }, {E3.7 0 }
-  - **[PCIDSS][Payment Card Industry Data Security Standard]**: {2.2.1 0 }, {2.2.3 0 }, {2.2.4 0 }, {2.2.5 0 }, {2.2.6 0 }, {6.2.1 0 }, {12.3.1 0 }, {12.8.1 0 }
-  - **[800-161][NIST Special Publication 800-161 - Cybersecurity Supply Chain Risk Management Practices for Systems and Organizations]**: {CM-2 0 }, {PL-2 0 }, {PL-8 0 }, {RA-3 0 }, {SA-15 0 }
+  - **[BPB][Best Practices Badge]**: B-B-10, B-S-7
+  - **[CRA][Cyber Resilience Act]**: 1.2a, 1.2b
+  - **[SSDF][Secure Software Development Framework]**: PW.1.2
+  - **[CSF][Cybersecurity Framework]**: GV.OC-05, ID.AM-01
+  - **ISO-[18974][OpenChain]**: 4.1.4
+  - **[OpenCRE][OpenCRE]**: 155-155, 068-102, 072-713, 820-878
+  - **PSSCRM**: E3.4, E3.7
+  - **[PCIDSS][Payment Card Industry Data Security Standard]**: 2.2.1, 2.2.3, 2.2.4, 2.2.5, 2.2.6, 6.2.1, 12.3.1, 12.8.1
+  - **[800-161][NIST Special Publication 800-161 - Cybersecurity Supply Chain Risk Management Practices for Systems and Organizations]**: CM-2, PL-2, PL-8, RA-3, SA-15
 
 
 ---
@@ -2269,17 +2269,17 @@ Ensure this is updated for new features or breaking changes.
 #### External Framework Mappings
 
   
-  - **[BPB][Best Practices Badge]**: {B-S-8 0 }, {S-G-1 0 }
-  - **[CRA][Cyber Resilience Act]**: {1.1 0 }, {1.2j 0 }, {1.2k 0 }, {2.2 0 }
-  - **[SSDF][Secure Software Development Framework]**: {PO.5.1 0 }, {PW.1.1 0 }
-  - **[CSF][Cybersecurity Framework]**: {ID.RA-01 0 }, {ID.RA-04 0 }, {ID.RA-05 0 }, {DE.AE-07 0 }
-  - **ISO-[18974][OpenChain]**: {4.1.5 0 }
-  - **[OpenCRE][OpenCRE]**: {068-102 0 }, {154-031 0 }, {888-770 0 }
-  - **PSSCRM**: {G4.3 0 }, {G5.2 0 }, {P2.1 0 }
-  - **[SAMM][Proactive Software Supply Chain Risk Management Framework]**: {Governance -Create and Promote Lvl1 0 }, {Design -Threat Assessment -Application Risk Profile Lvl1 0 }, {Design -Threat Assessment -Threat Modeling Lvl1 0 }, {Verification -Architecture Assessment -Architecture Mitigation Lvl2 0 }
-  - **[PCIDSS][Payment Card Industry Data Security Standard]**: {2.2.4 0 }, {2.2.5 0 }, {2.2.6 0 }, {6.2.1 0 }, {6.2.3.1 0 }, {6.3.2 0 }, {6.4.2 0 }, {11.3.1 0 }, {12.3.1 0 }
-  - **UKSSCOP**: {1.4 0 }, {3.3 0 }
-  - **[800-161][NIST Special Publication 800-161 - Cybersecurity Supply Chain Risk Management Practices for Systems and Organizations]**: {CA-2 0 }, {CA-2(3) 0 }, {PM-30 0 }, {RA-3 0 }, {SA-11 0 }, {SA-15 0 }, {SA-15(3) 0 }, {SA-15(8) 0 }, {SI-3 0 }, {SR-3 0 }, {SR-3(3) 0 }, {SR-6 0 }, {SR-7 0 }
+  - **[BPB][Best Practices Badge]**: B-S-8, S-G-1
+  - **[CRA][Cyber Resilience Act]**: 1.1, 1.2j, 1.2k, 2.2
+  - **[SSDF][Secure Software Development Framework]**: PO.5.1, PW.1.1
+  - **[CSF][Cybersecurity Framework]**: ID.RA-01, ID.RA-04, ID.RA-05, DE.AE-07
+  - **ISO-[18974][OpenChain]**: 4.1.5
+  - **[OpenCRE][OpenCRE]**: 068-102, 154-031, 888-770
+  - **PSSCRM**: G4.3, G5.2, P2.1
+  - **[SAMM][Proactive Software Supply Chain Risk Management Framework]**: Governance -Create and Promote Lvl1, Design -Threat Assessment -Application Risk Profile Lvl1, Design -Threat Assessment -Threat Modeling Lvl1, Verification -Architecture Assessment -Architecture Mitigation Lvl2
+  - **[PCIDSS][Payment Card Industry Data Security Standard]**: 2.2.4, 2.2.5, 2.2.6, 6.2.1, 6.2.3.1, 6.3.2, 6.4.2, 11.3.1, 12.3.1
+  - **UKSSCOP**: 1.4, 3.3
+  - **[800-161][NIST Special Publication 800-161 - Cybersecurity Supply Chain Risk Management Practices for Systems and Organizations]**: CA-2, CA-2(3), PM-30, RA-3, SA-11, SA-15, SA-15(3), SA-15(8), SI-3, SR-3, SR-3(3), SR-6, SR-7
 
 
 ---
@@ -2329,18 +2329,18 @@ project will respond and address reported issues.
 #### External Framework Mappings
 
   
-  - **[BPB][Best Practices Badge]**: {R-B-6 0 }, {R-B-8 0 }, {R-S-2 0 }, {S-B-14 0 }, {S-B-15 0 }
-  - **[CRA][Cyber Resilience Act]**: {2.1 0 }, {2.2 0 }, {2.3 0 }, {2.6 0 }, {2.7 0 }, {2.8 0 }
-  - **[SSDF][Secure Software Development Framework]**: {RV.1.3 0 }
-  - **[CSF][Cybersecurity Framework]**: {GV.PO-01 0 }, {GV.PO-02 0 }, {ID.RA-01 0 }, {ID.RA-08 0 }
-  - **ISO-[18974][OpenChain]**: {4.1.5 0 }, {4.2.1 0 }, {4.3.2 0 }
-  - **[OpenCRE][OpenCRE]**: {887-750 0 }
-  - **Scorecard**: {Security-Policy 0 }
-  - **PSSCRM**: {D1.1 0 }, {D1.2 0 }, {D1.3 0 }, {D1.5 0 }
-  - **[SAMM][Proactive Software Supply Chain Risk Management Framework]**: {Governance -Create and Promote Lvl2 0 }, {Governance -Policy &amp; Compliance -Policy &amp; Standards Lvl1 0 }, {Implementation -Defect Management -Defect Tracking Lvl1 0 }, {Implementation -Defect Management -Defect Tracking Lvl2 0 }, {Implementation -Defect Management -Defect Tracking Lvl3 0 }, {Operations -Incident Management -Incident Response Lvl1 0 }, {Operations -Incident Management -Incident Response Lvl2 0 }, {Operations -Incident Management -Incident Response Lvl3 0 }
-  - **[PCIDSS][Payment Card Industry Data Security Standard]**: {2.1.1 0 }, {3.1.1 0 }, {4.1.1 0 }, {5.1.1 0 }, {6.1.1 0 }, {6.3.1 0 }, {6.3.2 0 }, {7.1.1 0 }, {8.1.1 0 }, {11.1.1 0 }, {11.2.1 0 }, {12.1.1 0 }, {12.1.3 0 }
-  - **UKSSCOP**: {3.2 0 }, {3.4 0 }, {3.5 0 }
-  - **[800-161][NIST Special Publication 800-161 - Cybersecurity Supply Chain Risk Management Practices for Systems and Organizations]**: {IR-1 0 }, {IR-4 0 }, {IR-6 0 }, {IR-7(1) 0 }, {IR-8 0 }, {SI-2 0 }
+  - **[BPB][Best Practices Badge]**: R-B-6, R-B-8, R-S-2, S-B-14, S-B-15
+  - **[CRA][Cyber Resilience Act]**: 2.1, 2.2, 2.3, 2.6, 2.7, 2.8
+  - **[SSDF][Secure Software Development Framework]**: RV.1.3
+  - **[CSF][Cybersecurity Framework]**: GV.PO-01, GV.PO-02, ID.RA-01, ID.RA-08
+  - **ISO-[18974][OpenChain]**: 4.1.5, 4.2.1, 4.3.2
+  - **[OpenCRE][OpenCRE]**: 887-750
+  - **Scorecard**: Security-Policy
+  - **PSSCRM**: D1.1, D1.2, D1.3, D1.5
+  - **[SAMM][Proactive Software Supply Chain Risk Management Framework]**: Governance -Create and Promote Lvl2, Governance -Policy &amp; Compliance -Policy &amp; Standards Lvl1, Implementation -Defect Management -Defect Tracking Lvl1, Implementation -Defect Management -Defect Tracking Lvl2, Implementation -Defect Management -Defect Tracking Lvl3, Operations -Incident Management -Incident Response Lvl1, Operations -Incident Management -Incident Response Lvl2, Operations -Incident Management -Incident Response Lvl3
+  - **[PCIDSS][Payment Card Industry Data Security Standard]**: 2.1.1, 3.1.1, 4.1.1, 5.1.1, 6.1.1, 6.3.1, 6.3.2, 7.1.1, 8.1.1, 11.1.1, 11.2.1, 12.1.1, 12.1.3
+  - **UKSSCOP**: 3.2, 3.4, 3.5
+  - **[800-161][NIST Special Publication 800-161 - Cybersecurity Supply Chain Risk Management Practices for Systems and Organizations]**: IR-1, IR-4, IR-6, IR-7(1), IR-8, SI-2
 
 
 ---
@@ -2375,17 +2375,17 @@ contacts for the project.
 #### External Framework Mappings
 
   
-  - **[BPB][Best Practices Badge]**: {B-S-8 0 }
-  - **[CRA][Cyber Resilience Act]**: {2.5 0 }
-  - **[SSDF][Secure Software Development Framework]**: {RV.1.3 0 }
-  - **[CSF][Cybersecurity Framework]**: {GV.PO-01 0 }, {GV.PO-02 0 }, {ID.RA-01 0 }
-  - **ISO-[18974][OpenChain]**: {4.1.1 0 }, {4.1.3 0 }, {4.1.5 0 }, {4.2.2 0 }
-  - **[OpenCRE][OpenCRE]**: {464-513 0 }
-  - **Scorecard**: {Security-Policy 0 }
-  - **[SAMM][Proactive Software Supply Chain Risk Management Framework]**: {Governance -Policy&amp;Compliance -Policy&amp;Standards Lvl2 0 }
-  - **[PCIDSS][Payment Card Industry Data Security Standard]**: {6.3.3 0 }, {12.1.1 0 }, {12.10.2 0 }
-  - **UKSSCOP**: {3.2 0 }
-  - **[800-161][NIST Special Publication 800-161 - Cybersecurity Supply Chain Risk Management Practices for Systems and Organizations]**: {IR-1 0 }, {IR-4 0 }, {IR-6 0 }, {IR-8 0 }
+  - **[BPB][Best Practices Badge]**: B-S-8
+  - **[CRA][Cyber Resilience Act]**: 2.5
+  - **[SSDF][Secure Software Development Framework]**: RV.1.3
+  - **[CSF][Cybersecurity Framework]**: GV.PO-01, GV.PO-02, ID.RA-01
+  - **ISO-[18974][OpenChain]**: 4.1.1, 4.1.3, 4.1.5, 4.2.2
+  - **[OpenCRE][OpenCRE]**: 464-513
+  - **Scorecard**: Security-Policy
+  - **[SAMM][Proactive Software Supply Chain Risk Management Framework]**: Governance -Policy&amp;Compliance -Policy&amp;Standards Lvl2
+  - **[PCIDSS][Payment Card Industry Data Security Standard]**: 6.3.3, 12.1.1, 12.10.2
+  - **UKSSCOP**: 3.2
+  - **[800-161][NIST Special Publication 800-161 - Cybersecurity Supply Chain Risk Management Practices for Systems and Organizations]**: IR-1, IR-4, IR-6, IR-8
 
 
 ---
@@ -2422,13 +2422,13 @@ contacts, or other methods.
 #### External Framework Mappings
 
   
-  - **[BPB][Best Practices Badge]**: {R-B-7 0 }
-  - **[CRA][Cyber Resilience Act]**: {2.5 0 }, {2.6 0 }
-  - **[OpenCRE][OpenCRE]**: {308-514 0 }
-  - **[SAMM][Proactive Software Supply Chain Risk Management Framework]**: {Operations -Incident Management -Incident Response Lvl3 0 }
-  - **[PCIDSS][Payment Card Industry Data Security Standard]**: {6.3.1 0 }, {6.3.3 0 }, {12.10.2 0 }
-  - **UKSSCOP**: {3.2 0 }
-  - **[800-161][NIST Special Publication 800-161 - Cybersecurity Supply Chain Risk Management Practices for Systems and Organizations]**: {IR-6 0 }
+  - **[BPB][Best Practices Badge]**: R-B-7
+  - **[CRA][Cyber Resilience Act]**: 2.5, 2.6
+  - **[OpenCRE][OpenCRE]**: 308-514
+  - **[SAMM][Proactive Software Supply Chain Risk Management Framework]**: Operations -Incident Management -Incident Response Lvl3
+  - **[PCIDSS][Payment Card Industry Data Security Standard]**: 6.3.1, 6.3.3, 12.10.2
+  - **UKSSCOP**: 3.2
+  - **[800-161][NIST Special Publication 800-161 - Cybersecurity Supply Chain Risk Management Practices for Systems and Organizations]**: IR-6
 
 
 ---
@@ -2482,14 +2482,14 @@ executed.
 #### External Framework Mappings
 
   
-  - **[CRA][Cyber Resilience Act]**: {1.2a 0 }, {1.2b 0 }, {2.1 0 }, {2.4 0 }, {2.6 0 }
-  - **[SSDF][Secure Software Development Framework]**: {PO.4.1 0 }, {RV.2.1 0 }, {RV.2.2 0 }
-  - **[CSF][Cybersecurity Framework]**: {ID.RA-01 0 }
-  - **ISO-[18974][OpenChain]**: {4.1.5 0 }
-  - **PSSCRM**: {G2.2 0 }, {D1.1 0 }
-  - **[PCIDSS][Payment Card Industry Data Security Standard]**: {6.2.3 0 }, {6.3.1 0 }, {6.3.2 0 }, {6.3.3 0 }, {11.3.1 0 }
-  - **UKSSCOP**: {3.4 0 }, {3.5 0 }, {4.3 0 }
-  - **[800-161][NIST Special Publication 800-161 - Cybersecurity Supply Chain Risk Management Practices for Systems and Organizations]**: {CA-7 0 }, {CM-3 0 }, {CM-8 0 }, {IR-5 0 }, {SI-2 0 }, {SI-4 0 }, {SI-5 0 }
+  - **[CRA][Cyber Resilience Act]**: 1.2a, 1.2b, 2.1, 2.4, 2.6
+  - **[SSDF][Secure Software Development Framework]**: PO.4.1, RV.2.1, RV.2.2
+  - **[CSF][Cybersecurity Framework]**: ID.RA-01
+  - **ISO-[18974][OpenChain]**: 4.1.5
+  - **PSSCRM**: G2.2, D1.1
+  - **[PCIDSS][Payment Card Industry Data Security Standard]**: 6.2.3, 6.3.1, 6.3.2, 6.3.3, 11.3.1
+  - **UKSSCOP**: 3.4, 3.5, 4.3
+  - **[800-161][NIST Special Publication 800-161 - Cybersecurity Supply Chain Risk Management Practices for Systems and Organizations]**: CA-7, CM-3, CM-8, IR-5, SI-2, SI-4, SI-5
 
 
 ---
@@ -2562,18 +2562,18 @@ can be merged.
 #### External Framework Mappings
 
   
-  - **[BPB][Best Practices Badge]**: {B-S-8 0 }, {Q-B-12 0 }, {Q-S-9 0 }, {S-B-14 0 }, {S-B-15 0 }, {A-B-1 0 }, {A-B-3 0 }, {A-B-8 0 }, {A-S-1 0 }
-  - **[CRA][Cyber Resilience Act]**: {1.2a 0 }, {1.2b 0 }, {1.2c 0 }, {2.1 0 }, {2.2 0 }, {2.3 0 }, {2.4 0 }
-  - **[SSDF][Secure Software Development Framework]**: {PO.4 0 }, {PW.1.2 0 }, {PW.8.1 0 }, {RV.1.2 0 }, {RV.1.3 0 }, {RV.2.1 0 }, {RV.2.2 0 }
-  - **[CSF][Cybersecurity Framework]**: {GV.RM-05 0 }, {GV.RM-06 0 }, {GV.PO-01 0 }, {GV.PO-02 0 }, {ID.RA-01 0 }, {ID.RA-08 0 }, {ID.IM-02 0 }
-  - **ISO-[18974][OpenChain]**: {4.1.5 0 }, {4.2.1 0 }, {4.2.2 0 }, {4.3.2 0 }
-  - **[OpenCRE][OpenCRE]**: {155-155 0 }, {124-564 0 }, {757-271 0 }, {464-513 0 }, {611-158 0 }, {207-435 0 }, {088-377 0 }
-  - **Scorecard**: {Security-Policy 0 }, {Vulnerabilities 0 }
-  - **PSSCRM**: {G5.4 0 }, {P4.1 0 }, {P4.2 0 }, {P4.3 0 }, {P4.4 0 }, {P4.5 0 }
-  - **[SAMM][Proactive Software Supply Chain Risk Management Framework]**: {Implementation -Secure Build-Build Process Lvl3 0 }, {Implementation -Software Dependencies Lvl3 0 }, {Verification -Security Testing -Scalable Baseline Lvl1 0 }, {Verification -Security Testing -Scalable Baseline Lvl3 0 }
-  - **[PCIDSS][Payment Card Industry Data Security Standard]**: {6.2.3 0 }, {6.3.1 0 }, {6.3.2 0 }, {6.4.1 0 }, {6.4.2 0 }
-  - **UKSSCOP**: {1.2 0 }, {3.3 0 }
-  - **[800-161][NIST Special Publication 800-161 - Cybersecurity Supply Chain Risk Management Practices for Systems and Organizations]**: {CA-7 0 }, {RA-5 0 }, {SA-11 0 }, {SI-2 0 }, {SI-3 0 }
+  - **[BPB][Best Practices Badge]**: B-S-8, Q-B-12, Q-S-9, S-B-14, S-B-15, A-B-1, A-B-3, A-B-8, A-S-1
+  - **[CRA][Cyber Resilience Act]**: 1.2a, 1.2b, 1.2c, 2.1, 2.2, 2.3, 2.4
+  - **[SSDF][Secure Software Development Framework]**: PO.4, PW.1.2, PW.8.1, RV.1.2, RV.1.3, RV.2.1, RV.2.2
+  - **[CSF][Cybersecurity Framework]**: GV.RM-05, GV.RM-06, GV.PO-01, GV.PO-02, ID.RA-01, ID.RA-08, ID.IM-02
+  - **ISO-[18974][OpenChain]**: 4.1.5, 4.2.1, 4.2.2, 4.3.2
+  - **[OpenCRE][OpenCRE]**: 155-155, 124-564, 757-271, 464-513, 611-158, 207-435, 088-377
+  - **Scorecard**: Security-Policy, Vulnerabilities
+  - **PSSCRM**: G5.4, P4.1, P4.2, P4.3, P4.4, P4.5
+  - **[SAMM][Proactive Software Supply Chain Risk Management Framework]**: Implementation -Secure Build-Build Process Lvl3, Implementation -Software Dependencies Lvl3, Verification -Security Testing -Scalable Baseline Lvl1, Verification -Security Testing -Scalable Baseline Lvl3
+  - **[PCIDSS][Payment Card Industry Data Security Standard]**: 6.2.3, 6.3.1, 6.3.2, 6.4.1, 6.4.2
+  - **UKSSCOP**: 1.2, 3.3
+  - **[800-161][NIST Special Publication 800-161 - Cybersecurity Supply Chain Risk Management Practices for Systems and Organizations]**: CA-7, RA-5, SA-11, SI-2, SI-3
 
 
 ---
@@ -2625,18 +2625,18 @@ can be merged.
 #### External Framework Mappings
 
   
-  - **[BPB][Best Practices Badge]**: {B-S-8 0 }, {Q-B-12 0 }, {Q-S-9 0 }, {S-B-14 0 }, {S-B-15 0 }, {A-B-1 0 }, {A-B-3 0 }, {A-B-8 0 }, {A-S-1 0 }
-  - **[CRA][Cyber Resilience Act]**: {1.2a 0 }, {1.2b 0 }, {1.2c 0 }, {2.1 0 }, {2.2 0 }, {2.3 0 }, {2.4 0 }
-  - **[SSDF][Secure Software Development Framework]**: {PO.4 0 }, {PW.1.2 0 }, {PW.8.1 0 }, {RV.1.2 0 }, {RV.1.3 0 }, {RV.2.1 0 }, {RV 2.2 0 }
-  - **[CSF][Cybersecurity Framework]**: {GV.RM-05 0 }, {GV.RM-06 0 }, {GV.PO-01 0 }, {GV.PO-02 0 }, {ID.RA-01 0 }, {ID.RA-08 0 }, {ID.IM-02 0 }
-  - **ISO-[18974][OpenChain]**: {4.1.5 0 }, {4.2.1 0 }, {4.2.2 0 }, {4.3.2 0 }
-  - **[OpenCRE][OpenCRE]**: {155-155 0 }, {124-564 0 }, {757-271 0 }, {464-513 0 }, {611-158 0 }, {207-435 0 }, {088-377 0 }
-  - **Scorecard**: {Security-Policy 0 }, {Vulnerabilities 0 }, {SAST 0 }
-  - **PSSCRM**: {G5.4 0 }, {P4.1 0 }, {P4.2 0 }, {P4.3 0 }, {P4.4 0 }, {P4.5 0 }
-  - **[SAMM][Proactive Software Supply Chain Risk Management Framework]**: {Implementation -Secure Build-Build Process Lvl3 0 }, {Implementation -Software Dependencies Lvl3 0 }, {Verification -Security Testing -Scalable Baseline Lvl1 0 }, {Verification -Security Testing -Scalable Baseline Lvl3 0 }
-  - **[PCIDSS][Payment Card Industry Data Security Standard]**: {6.2.3 0 }, {6.3.1 0 }, {6.3.2 0 }, {6.4.1 0 }, {6.4.2 0 }, {6.5.2 0 }
-  - **UKSSCOP**: {1.3 0 }, {1.4 0 }
-  - **[800-161][NIST Special Publication 800-161 - Cybersecurity Supply Chain Risk Management Practices for Systems and Organizations]**: {CA-7 0 }, {RA-5 0 }, {SA-11 0 }, {SI-2 0 }, {SI-3 0 }
+  - **[BPB][Best Practices Badge]**: B-S-8, Q-B-12, Q-S-9, S-B-14, S-B-15, A-B-1, A-B-3, A-B-8, A-S-1
+  - **[CRA][Cyber Resilience Act]**: 1.2a, 1.2b, 1.2c, 2.1, 2.2, 2.3, 2.4
+  - **[SSDF][Secure Software Development Framework]**: PO.4, PW.1.2, PW.8.1, RV.1.2, RV.1.3, RV.2.1, RV 2.2
+  - **[CSF][Cybersecurity Framework]**: GV.RM-05, GV.RM-06, GV.PO-01, GV.PO-02, ID.RA-01, ID.RA-08, ID.IM-02
+  - **ISO-[18974][OpenChain]**: 4.1.5, 4.2.1, 4.2.2, 4.3.2
+  - **[OpenCRE][OpenCRE]**: 155-155, 124-564, 757-271, 464-513, 611-158, 207-435, 088-377
+  - **Scorecard**: Security-Policy, Vulnerabilities, SAST
+  - **PSSCRM**: G5.4, P4.1, P4.2, P4.3, P4.4, P4.5
+  - **[SAMM][Proactive Software Supply Chain Risk Management Framework]**: Implementation -Secure Build-Build Process Lvl3, Implementation -Software Dependencies Lvl3, Verification -Security Testing -Scalable Baseline Lvl1, Verification -Security Testing -Scalable Baseline Lvl3
+  - **[PCIDSS][Payment Card Industry Data Security Standard]**: 6.2.3, 6.3.1, 6.3.2, 6.4.1, 6.4.2, 6.5.2
+  - **UKSSCOP**: 1.3, 1.4
+  - **[800-161][NIST Special Publication 800-161 - Cybersecurity Supply Chain Risk Management Practices for Systems and Organizations]**: CA-7, RA-5, SA-11, SI-2, SI-3
 
 
 ---


### PR DESCRIPTION
As noticed on Slack, #348 pulled in a new set of types from the Gemara library, and we ended up rendering `MappingEntry` types rather than strings in the template.  This fixes the rendering issue in the template.

