### PR TITLE
Also validate generator output with NIST OSCAL CLI 

### DIFF
--- a/.github/workflows/oscal-check.yaml
+++ b/.github/workflows/oscal-check.yaml
@@ -49,9 +49,15 @@ jobs:
           ./baseline-compiler oscal -b baseline > oscal-sample.json
           ./go-oscal validate --input-file oscal-sample.json 
 
-      - name: Validate Catalog with oscal-club/NIST CLI
-        uses: oscal-club/oscal-cli-action@b5b0c80a1a158797bea4475d13d12c494b56019b # v2.0.2
+      - name: Validate Catalog with oscal-club/metaschema CLI
+        uses: oscal-club/oscal-cli-action@6a8b6368885714e46fa1d4a65a6ce665902e08b7 # v2.1.0
         with:
+          args: catalog validate oscal-sample.json 
+
+      - name: Validate Catalog with oscal-club/NIST CLI
+        uses: oscal-club/oscal-cli-action@6a8b6368885714e46fa1d4a65a6ce665902e08b7 # v2.1.0
+        with:
+          oscalCliPackageUrl: https://repo1.maven.org/maven2/gov/nist/secauto/oscal/tools/oscal-cli/cli-core/1.0.3/cli-core-1.0.3-oscal-cli.tar.bz2
           args: catalog validate oscal-sample.json 
             
             


### PR DESCRIPTION
This PR adds another step to the validor workflow to check our OSCAL output with the NIST CLI