### PR TITLE
Add New Criteria - OSPS-DO-07 - Add build instructions requirement to project documentation

### DIFF
--- a/baseline/OSPS-DO.yaml
+++ b/baseline/OSPS-DO.yaml
@@ -465,7 +465,10 @@ controls:
           - Maturity Level 2
           - Maturity Level 3
         recommendation: |
-
+          It is recommended to publish this information alongside the project's
+          technical & design documentation on a publicly viewable resource such
+          as the source code repository, project website, or other channel.  
+        
   - id: OSPS-DO-07
     title: |
       The project documentation MUST provide instructions on how to build

--- a/baseline/OSPS-DO.yaml
+++ b/baseline/OSPS-DO.yaml
@@ -486,8 +486,8 @@ controls:
          include instructions on how to build the software, including required
          libraries, frameworks, SDKs, and dependencies.
       applicability:
-        Maturity Level 2
-        Maturity Level 3
+        - Maturity Level 2
+        - Maturity Level 3
       recommendation: |
         It is recommended to publish this information alongside the project's
         technical & design documentation on a publicly viewable resource such

--- a/baseline/OSPS-DO.yaml
+++ b/baseline/OSPS-DO.yaml
@@ -482,7 +482,7 @@ controls:
     assessment-requirements:
       -id: OSPS-DO-07.01
        text: |
-         When the project has made a release, the project documentation MUST
+         The project documentation MUST
          include instructions on how to build the software, including required
          =libraries, frameworks, SDKs, and dependencies.
       applicability:

--- a/baseline/OSPS-DO.yaml
+++ b/baseline/OSPS-DO.yaml
@@ -484,7 +484,7 @@ controls:
        text: |
          The project documentation MUST
          include instructions on how to build the software, including required
-         =libraries, frameworks, SDKs, and dependencies.
+         libraries, frameworks, SDKs, and dependencies.
       applicability:
         Maturity Level 2
         Maturity Level 3

--- a/baseline/OSPS-DO.yaml
+++ b/baseline/OSPS-DO.yaml
@@ -465,6 +465,28 @@ controls:
           - Maturity Level 2
           - Maturity Level 3
         recommendation: |
-          It is recommended to publish this information alongside the project's
-          technical & design documentation on a publicly viewable resource such
-          as the source code repository, project website, or other channel.
+
+  - id: OSPS-DO-07
+    title: |
+      The project documentation MUST provide instructions on how to build
+      from source code.
+    objective: |
+      Ensure that users have a clear and comprehensive instructions on how
+      to build the software from source code.
+    guideline-mappings:
+      - reference-id: 
+        entries:
+          - reference-id:
+    assessment-requirements:
+      -id: OSPS-DO-07.01
+       text: |
+         When the project has made a release, the project documentation MUST
+         include instructions on how to build the software, including required
+         =libraries, frameworks, SDKs, and dependencies.
+      applicability:
+        Maturity Level 2
+        Maturity Level 3
+      recommendation: |
+        It is recommended to publish this information alongside the project's
+        technical & design documentation on a publicly viewable resource such
+        as the source code repository, project website, or other channel.  

--- a/baseline/OSPS-DO.yaml
+++ b/baseline/OSPS-DO.yaml
@@ -471,8 +471,7 @@ controls:
         
   - id: OSPS-DO-07
     title: |
-      The project documentation MUST provide instructions on how to build
-      from source code.
+      Provide Instructions on How to Build From Source
     objective: |
       Ensure that users have a clear and comprehensive instructions on how
       to build the software from source code.

--- a/baseline/OSPS-DO.yaml
+++ b/baseline/OSPS-DO.yaml
@@ -490,5 +490,6 @@ controls:
           - Maturity Level 3
         recommendation: |
           It is recommended to publish this information alongside the project's
-          technical & design documentation on a publicly viewable resource such
-          as the source code repository, project website, or other channel.
+          contributor documentation, such as in `CONTRIBUTING.md` or other
+          developer task documentation. This may also be documented using
+          `Makefile` targets or other automation scripts.

--- a/baseline/OSPS-DO.yaml
+++ b/baseline/OSPS-DO.yaml
@@ -480,15 +480,15 @@ controls:
         entries:
           - reference-id:
     assessment-requirements:
-      -id: OSPS-DO-07.01
-       text: |
-         The project documentation MUST
-         include instructions on how to build the software, including required
-         libraries, frameworks, SDKs, and dependencies.
-      applicability:
-        - Maturity Level 2
-        - Maturity Level 3
-      recommendation: |
-        It is recommended to publish this information alongside the project's
-        technical & design documentation on a publicly viewable resource such
-        as the source code repository, project website, or other channel.  
+      - id: OSPS-DO-07.01
+        text: |
+          The project documentation MUST
+          include instructions on how to build the software, including required
+          libraries, frameworks, SDKs, and dependencies.
+        applicability:
+          - Maturity Level 2
+          - Maturity Level 3
+        recommendation: |
+          It is recommended to publish this information alongside the project's
+          technical & design documentation on a publicly viewable resource such
+          as the source code repository, project website, or other channel.


### PR DESCRIPTION
Added requirement for project documentation to include build instructions and recommendations for publishing this information.  see https://github.com/ossf/security-baseline/issues/472