### PR TITLE
fix: rename `oscal` --out flag to --output for consistency

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ Use the `--help` flag for more options.
 
 ### oscal
 
-This command reads the YAML OSPS Baseline data files and translates the catalog of controls into [OSCAL](https://pages.nist.gov/OSCAL/) format. It writes the JSON output to STDOUT by default. You can specify a file with `--out`.
+This command reads the YAML OSPS Baseline data files and translates the catalog of controls into [OSCAL](https://pages.nist.gov/OSCAL/) format. It writes the JSON output to STDOUT by default. You can specify a file with `--output`.
 
 Use the `--help` flag for more options.
 

--- a/cmd/internal/cmd/oscal.go
+++ b/cmd/internal/cmd/oscal.go
@@ -36,7 +36,7 @@ func (o *oscalOptions) AddFlags(cmd *cobra.Command) {
 	)
 
 	cmd.PersistentFlags().StringVarP(
-		&o.outPath, "out", "o", "", "path to output file (defaults to STDOUT)",
+		&o.outPath, "output", "o", "", "path to output file (defaults to STDOUT)",
 	)
 }
 


### PR DESCRIPTION
# fix: rename `oscal` command's `--out` flag to `--output`

---

## Problem
The `oscal` command uses `--out` as its output file flag, while the `compile` command 
uses `--output` for the same purpose. This inconsistency forces users to remember 
different flag names for the same operation depending on which command they are using.

---

## Root Cause
The `oscal` and `compile` commands were implemented without a shared flag naming 
convention, causing the same logical argument — the output file path — to be named 
differently across the two commands.

---

## Fix
- Renamed flag in `cmd/oscal.go` from `"out"` to `"output"` in the `StringVarP` call
- Shorthand `-o` remains unchanged, preserving backward compatibility
- Updated `README.md` to reflect the new `--output` flag
- Confirmed no other files reference the old `--out` flag

---

## Result
- `go build` passes with no errors
- `--output` generates valid OSCAL JSON output successfully
- `--out` correctly returns `ERROR: unknown flag: --out` confirming removal
- `-o` shorthand continues to work as expected

Fixes #282