### PR TITLE
Add LICENSES/ per issue #489

### DIFF
--- a/baseline/OSPS-LE.yaml
+++ b/baseline/OSPS-LE.yaml
@@ -84,7 +84,7 @@ criteria:
     details: |
       Include the project's source code license in
       the project's LICENSE file, COPYING file,
-      or LICENSE/
+      LICENSES/ directory, or LICENSE/
       directory to provide visibility and clarity
       on the licensing terms. The filename MAY
       have an extension.


### PR DESCRIPTION
Many projects use LICENSES/ directory not a LICENSE/ directory, per <https://reuse.software/faq/>. While we *could* allow arbitrary directories, having a *short* list of places to look makes tooling and analysis much easier. The naming also makes more sense, because the usual *reason* to have a directory is because there is more than 1 (plural) licenses involved.

So let's allow LICENSES/ but specifically specify it.