### PR TITLE
Add LICENSES/ per issue #489

### DIFF
--- a/baseline/OSPS-LE.yaml
+++ b/baseline/OSPS-LE.yaml
@@ -166,15 +166,16 @@ controls:
       - id: OSPS-LE-03.01
         text: |
           While active, the license for the source code MUST be maintained in
-          the corresponding repository's LICENSE file, COPYING file, or
-          LICENSE/ directory.
+          the corresponding repository's LICENSE file, COPYING file,
+          LICENSES/ directory, or LICENSE/ directory.
         applicability:
           - Maturity Level 1
           - Maturity Level 2
           - Maturity Level 3
         recommendation: |
           Include the project's source code license in the project's LICENSE
-          file, COPYING file, or LICENSE/ directory to provide visibility and
+          file, COPYING file, LICENSES/ directory, or LICENSE/ directory
+          to provide visibility and
           clarity on the licensing terms. The filename MAY have an extension.
           If the project has multiple repositories, ensure that each repository
           includes the license file.


### PR DESCRIPTION
Allow using a LICENSES/ directory as well as a LICENSE/ directory. Many projects use LICENSES/ directory, not a LICENSE/ directory, per <https://reuse.software/faq/> and the Best Practices Badge metal criterion license_location in
https://www.bestpractices.dev/en/criteria/0?details=true&rationale=true#license_location

While we *could* allow arbitrary directories, having a *short* list of places to look makes tooling and analysis much easier. The naming also makes more sense, because the usual *reason* to have a directory is because there is more than 1 (plural) licenses involved. Valid licenses are a vital precondition for security; before you can review code, fix code, or distribute those fixed results, it must be legal to read, modify, and/or release that code.

So let's allow the LICENSES/ subdirectory but specify it as an option so automated tooling will quickly find it.