### PR TITLE
Bump to go-gemara 0.3.0 and updates for new function signature

### DIFF
--- a/cmd/go.mod
+++ b/cmd/go.mod
@@ -4,7 +4,7 @@ go 1.25.0
 
 require (
 	github.com/defenseunicorns/go-oscal v0.7.0
-	github.com/gemaraproj/go-gemara v0.1.1
+	github.com/gemaraproj/go-gemara v0.3.0
 	github.com/goccy/go-yaml v1.19.2
 	github.com/spf13/cobra v1.10.2
 )

--- a/cmd/go.sum
+++ b/cmd/go.sum
@@ -6,8 +6,8 @@ github.com/defenseunicorns/go-oscal v0.7.0 h1:Ji9Yw3zEkbUfKZ8Gotoi9ExjUV/h3jmFLJ
 github.com/defenseunicorns/go-oscal v0.7.0/go.mod h1:OPuLRz6v7qhSaKIUgr+bK6ykhYq7FpZozSn2cVZJhMs=
 github.com/dlclark/regexp2 v1.11.0 h1:G/nrcoOa7ZXlpoa/91N3X7mM3r8eIlMBBJZvsz/mxKI=
 github.com/dlclark/regexp2 v1.11.0/go.mod h1:DHkYz0B9wPfa6wondMfaivmHpzrQ3v9q8cnmRbL6yW8=
-github.com/gemaraproj/go-gemara v0.1.1 h1:vxOj8Inp93P2CllxZA42+x0mE7OgE8KefZlU7X7+zZs=
-github.com/gemaraproj/go-gemara v0.1.1/go.mod h1:soDwOy6Xhhi6evU7viVZ1WPYnGLHWFEbnL0AMha+/v4=
+github.com/gemaraproj/go-gemara v0.3.0 h1:azCDwI7kR1tDF9+KIIV+EQYbb1uNNZhA++RoU63ImZk=
+github.com/gemaraproj/go-gemara v0.3.0/go.mod h1:soDwOy6Xhhi6evU7viVZ1WPYnGLHWFEbnL0AMha+/v4=
 github.com/goccy/go-yaml v1.19.2 h1:PmFC1S6h8ljIz6gMRBopkjP1TVT7xuwrButHID66PoM=
 github.com/goccy/go-yaml v1.19.2/go.mod h1:XBurs7gK8ATbW4ZPGKgcbrY1Br56PdM69F7LkFRi1kA=
 github.com/google/go-cmp v0.7.0 h1:wk8382ETsv4JYUZwIsn6YpYiWiBsYLSJiTsyBybVuN8=

--- a/cmd/pkg/baseline/loader.go
+++ b/cmd/pkg/baseline/loader.go
@@ -4,11 +4,13 @@
 package baseline
 
 import (
+	"context"
 	"fmt"
 	"os"
 	"path/filepath"
 
 	"github.com/gemaraproj/go-gemara"
+	"github.com/gemaraproj/go-gemara/fetcher"
 	"github.com/goccy/go-yaml"
 
 	"github.com/ossf/security-baseline/pkg/types"
@@ -100,7 +102,7 @@ func (l *Loader) loadControlFamilies(catalog *gemara.ControlCatalog) error {
 		familyPaths = append(familyPaths, familyPath)
 	}
 
-	if err := catalog.LoadFiles(familyPaths); err != nil {
+	if err := catalog.LoadFiles(context.Background(), &fetcher.URI{}, familyPaths); err != nil {
 		return fmt.Errorf("error loading controls families: %w", err)
 	}
 


### PR DESCRIPTION
Follows on #500 and adds fixes in the `baseline-compiler` for the change to `catalog.LoadFiles()`