### PR TITLE
deps: bump github.com/gemaraproj/go-gemara from 0.4.0 to 0.5.0

### DIFF
--- a/cmd/go.mod
+++ b/cmd/go.mod
@@ -4,7 +4,7 @@ go 1.25.0
 
 require (
 	github.com/defenseunicorns/go-oscal v0.7.0
-	github.com/gemaraproj/go-gemara v0.4.0
+	github.com/gemaraproj/go-gemara v0.5.0
 	github.com/goccy/go-yaml v1.19.2
 	github.com/spf13/cobra v1.10.2
 )

--- a/cmd/go.sum
+++ b/cmd/go.sum
@@ -8,6 +8,8 @@ github.com/dlclark/regexp2 v1.11.0 h1:G/nrcoOa7ZXlpoa/91N3X7mM3r8eIlMBBJZvsz/mxK
 github.com/dlclark/regexp2 v1.11.0/go.mod h1:DHkYz0B9wPfa6wondMfaivmHpzrQ3v9q8cnmRbL6yW8=
 github.com/gemaraproj/go-gemara v0.4.0 h1:zyn7bJiqAitrRBCDlMYVLb8C1XhDWG2wI0j+pHad3HA=
 github.com/gemaraproj/go-gemara v0.4.0/go.mod h1:knXQmQ4f7vB18eb6TcUCP2A3dqQpn+oZdyz74Qe1+ac=
+github.com/gemaraproj/go-gemara v0.5.0 h1:sKDj3R7fX8tdlksShWGCLUl/sLvo+tGh1xAFs1JaoHU=
+github.com/gemaraproj/go-gemara v0.5.0/go.mod h1:knXQmQ4f7vB18eb6TcUCP2A3dqQpn+oZdyz74Qe1+ac=
 github.com/goccy/go-yaml v1.19.2 h1:PmFC1S6h8ljIz6gMRBopkjP1TVT7xuwrButHID66PoM=
 github.com/goccy/go-yaml v1.19.2/go.mod h1:XBurs7gK8ATbW4ZPGKgcbrY1Br56PdM69F7LkFRi1kA=
 github.com/google/go-cmp v0.7.0 h1:wk8382ETsv4JYUZwIsn6YpYiWiBsYLSJiTsyBybVuN8=

--- a/cmd/pkg/baseline/generator_oscal.go
+++ b/cmd/pkg/baseline/generator_oscal.go
@@ -21,7 +21,7 @@ const (
 )
 
 func (g *Generator) ExportOSCAL(b *types.Baseline, w io.Writer) error {
-	oscalCatalog, err := gemaraconv.ControlCatalog(&b.Catalog).ToOSCAL(
+	oscalCatalog, err := gemaraconv.ControlCatalog(b.Catalog).ToOSCAL(
 		gemaraconv.WithCanonicalHrefFormat(canonicalHREF),
 		gemaraconv.WithControlHref(controlHREF))
 	if err != nil {


### PR DESCRIPTION
Adapt to breaking change: gemaraconv.ControlCatalog now accepts a value instead of a pointer.

Replaces #507 