### PR TITLE
ci: publish catalog and mapping documents to grc.store on release

### DIFF
--- a/.github/ISSUE_TEMPLATE/release.yaml
+++ b/.github/ISSUE_TEMPLATE/release.yaml
@@ -49,6 +49,8 @@ body:
         - label: |
             After the pull request is merged, git tag the commit
         - label: |
+            Publish a GitHub Release from that tag — this is what triggers the grc.store publish workflow; a bare git tag will not fire it
+        - label: |
             After the pull request is merged, send an email to the [mailing list](https://lists.openssf.org/g/openssf-sig-security-baseline)
         - label: |
             After the pull request is merged, notify OpenSSF's marketing team that we have a new release so that they can share it with the world

--- a/.github/actions/compile-and-vet/action.yml
+++ b/.github/actions/compile-and-vet/action.yml
@@ -1,0 +1,41 @@
+# SPDX-FileCopyrightText: Copyright 2026 The OSPS Baseline Authors
+# SPDX-License-Identifier: Apache-2.0
+---
+name: Compile and vet the baseline
+description: >
+  Builds baseline-compiler, assembles the baseline into a single Gemara
+  ControlCatalog at baseline.gemara.yaml, and vets that catalog plus every
+  mapping document against the CUE schema. Requires the repository to already
+  be checked out.
+
+runs:
+  using: composite
+  steps:
+    - name: Setup Go
+      uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6.5.0
+      with:
+        go-version-file: cmd/go.mod
+        check-latest: true
+        cache: true
+
+    - name: Setup CUE
+      uses: cue-lang/setup-cue@a93fa358375740cd8b0078f76355512b9208acb1 # v1.0.1
+      with:
+        version: latest
+
+    - name: Compile catalog to a single Gemara YAML
+      shell: bash
+      run: |
+        go build -C cmd/ -o ../baseline-compiler
+        ./baseline-compiler gemara -b baseline -o baseline.gemara.yaml
+
+    # One `cue vet` per mapping: vetting them together would unify all 14 into
+    # a single instance instead of checking each on its own.
+    - name: Validate catalog and mappings against CUE schema
+      shell: bash
+      run: |
+        cd schema
+        cue vet -d '#OSPSBaseline' . ../baseline.gemara.yaml
+        for f in ../baseline/mappings/*.yaml; do
+          cue vet -d '#OSPSMapping' . "$f"
+        done

--- a/.github/workflows/cue-validate.yaml
+++ b/.github/workflows/cue-validate.yaml
@@ -20,30 +20,7 @@ jobs:
         with:
           persist-credentials: false
 
-      - name: Setup Go
-        uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6.5.0
-        with:
-          go-version-file: cmd/go.mod
-          check-latest: true
-          cache: true
-
-      - name: Setup CUE
-        uses: cue-lang/setup-cue@a93fa358375740cd8b0078f76355512b9208acb1 # v1.0.1
-        with:
-          version: latest
-
-      - name: Generate Gemara output
-        run: |
-          go build -C cmd/  -o ../baseline-compiler
-          ./baseline-compiler gemara -b baseline > baseline.gemara.yaml
-
-      - name: Validate catalog against CUE schema
-        run: cd schema && cue vet -d '#OSPSBaseline' . ../baseline.gemara.yaml
-
-      - name: Validate mapping documents against CUE schema
-        run: |
-          cd schema
-          for f in ../baseline/mappings/*.yaml; do
-            echo "vetting $f"
-            cue vet -d '#OSPSMapping' . "$f"
-          done
+      # Shared with publish.yaml — the CUE gate must not drift between the
+      # workflow that checks a PR and the one that publishes.
+      - name: Compile catalog and vet it against the CUE schema
+        uses: ./.github/actions/compile-and-vet

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -8,11 +8,11 @@ name: Publish to grc.store
 # grcli. Triggered automatically when a GitHub Release is published; also
 # runnable manually for testing (dry_run defaults to true).
 #
-# Requirements:
-#   - Repository secret GRCLI_TOKEN: bearer token for the hub sync call.
-#     Obtain by running `grcli login` locally and copying the access token from
-#     ${XDG_DATA_HOME:-~/.local/share}/grcli/credentials.json, or by issuing a
-#     service-account token in the grc.store hub UI.
+# Auth:
+#   - grcli authenticates to grc.store via OIDC trusted publishing. The
+#     id-token: write permission below lets the runner mint an OIDC token
+#     that grcli exchanges for a hub credential. No static secrets needed —
+#     register this repo as a trusted publisher in the grc.store hub UI.
 #
 # Notes:
 #   - grcli is distributed as an OCI artifact (not a runnable container),
@@ -37,6 +37,7 @@ on:
 permissions:
   contents: read
   packages: read
+  id-token: write
 
 jobs:
   publish:
@@ -81,7 +82,6 @@ jobs:
 
       - name: Publish catalog and mapping documents to grc.store
         env:
-          GRCLI_TOKEN: ${{ secrets.GRCLI_TOKEN }}
           DRY_RUN: ${{ github.event.inputs.dry_run }}
           EVENT_NAME: ${{ github.event_name }}
           RELEASE_TAG: ${{ github.event.release.tag_name }}
@@ -108,9 +108,6 @@ jobs:
           if [ "${DRY_RUN:-false}" = "true" ]; then
             publish_args+=(--dry-run)
             echo "Running in DRY-RUN mode (no network, OCI layout written under grcli-out/)"
-          elif [ -z "${GRCLI_TOKEN:-}" ]; then
-            echo "::error::GRCLI_TOKEN secret is not set; cannot publish to grc.store"
-            exit 1
           fi
 
           staged="$RUNNER_TEMP/staged"

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -6,7 +6,7 @@ name: Publish to grc.store
 # Publishes the compiled OSPS Baseline ControlCatalog plus every MappingDocument
 # under baseline/mappings/ to the Gemara registry (https://hub.grc.store) using
 # grcli. Triggered automatically when a GitHub Release is published; also
-# runnable manually for testing (use the dry_run input to skip the network).
+# runnable manually for testing (dry_run defaults to true).
 #
 # Requirements:
 #   - Repository secret GRCLI_TOKEN: bearer token for the hub sync call.
@@ -15,10 +15,11 @@ name: Publish to grc.store
 #     service-account token in the grc.store hub UI.
 #
 # Notes:
-#   - The OCI tag for each artifact is taken from the release tag (or the
-#     workflow_dispatch input on manual runs). It is NOT taken from the
-#     artifact's metadata.version because the catalog and mapping documents
-#     are still marked draft: true.
+#   - grcli is distributed as an OCI artifact (not a runnable container),
+#     so we fetch it with oras instead of docker pull.
+#   - The OCI tag for each artifact comes from the artifact's own
+#     metadata.version field. Make sure metadata.version is bumped and
+#     `draft: true` is cleared before cutting a release.
 #   - Signing is disabled (--no-sign). To enable cosign signing, add a
 #     COSIGN_KEY secret and pass --cosign-key (or remove --no-sign once grcli
 #     supports keyless Sigstore signing in CI).
@@ -28,10 +29,6 @@ on:
     types: [published]
   workflow_dispatch:
     inputs:
-      tag:
-        description: "OCI tag to publish under (defaults to release tag; required for manual runs)"
-        required: false
-        default: ""
       dry_run:
         description: "Dry-run: build OCI layouts locally without pushing to the registry"
         type: boolean
@@ -39,13 +36,14 @@ on:
 
 permissions:
   contents: read
+  packages: read
 
 jobs:
   publish:
     name: Publish baseline catalog and mappings
     runs-on: ubuntu-latest
     env:
-      GRCLI_IMAGE: ghcr.io/revanite-io/grcli:latest
+      GRCLI_REF: ghcr.io/revanite-io/grcli:latest
     steps:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -59,48 +57,36 @@ jobs:
           check-latest: true
           cache: true
 
+      - name: Setup oras
+        uses: oras-project/setup-oras@8d34698a59f5ffe24821f0b48ab62a3de8b64b20 # v1.2.3
+
       - name: Build baseline-compiler
         run: go build -C cmd/ -o ../baseline-compiler
 
       - name: Compile catalog to single Gemara YAML
         run: ./baseline-compiler gemara -b baseline -o baseline.gemara.yaml
 
-      - name: Determine publish tag
-        id: tag
+      - name: Install grcli from OCI artifact
         env:
-          EVENT_NAME: ${{ github.event_name }}
-          RELEASE_TAG: ${{ github.event.release.tag_name }}
-          INPUT_TAG: ${{ github.event.inputs.tag }}
+          GHCR_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           set -euo pipefail
-          if [ "$EVENT_NAME" = "release" ]; then
-            tag="$RELEASE_TAG"
-          elif [ -n "$INPUT_TAG" ]; then
-            tag="$INPUT_TAG"
-          else
-            # Manual dispatch with no explicit tag: build a deterministic dev tag
-            # tied to the commit SHA. Only useful for dry-run publishing.
-            tag="v0.0.0-dev-${GITHUB_SHA:0:7}"
-          fi
-          if [ -z "$tag" ]; then
-            echo "::error::Unable to determine publish tag"
-            exit 1
-          fi
-          echo "tag=$tag" >> "$GITHUB_OUTPUT"
-          echo "Using publish tag: $tag"
-
-      - name: Pull grcli image
-        run: docker pull "$GRCLI_IMAGE"
+          mkdir -p "$RUNNER_TEMP/bin"
+          echo "$GHCR_TOKEN" | oras login ghcr.io -u "${{ github.actor }}" --password-stdin
+          cd "$RUNNER_TEMP/bin"
+          oras pull --platform linux/amd64 "$GRCLI_REF"
+          chmod +x grcli
+          echo "$RUNNER_TEMP/bin" >> "$GITHUB_PATH"
+          ./grcli --version
 
       - name: Publish catalog and mapping documents to grc.store
         env:
           GRCLI_TOKEN: ${{ secrets.GRCLI_TOKEN }}
-          PUBLISH_TAG: ${{ steps.tag.outputs.tag }}
           DRY_RUN: ${{ github.event.inputs.dry_run }}
         run: |
           set -euo pipefail
 
-          publish_args=(--tag "$PUBLISH_TAG" --no-sign)
+          publish_args=(--no-sign)
           if [ "${DRY_RUN:-false}" = "true" ]; then
             publish_args+=(--dry-run)
             echo "Running in DRY-RUN mode (no network, OCI layout written under grcli-out/)"
@@ -111,11 +97,8 @@ jobs:
 
           publish() {
             local file="$1"
-            echo "::group::Publishing $file (tag=$PUBLISH_TAG)"
-            docker run --rm \
-              -v "$PWD:/workspace" -w /workspace \
-              -e GRCLI_TOKEN \
-              "$GRCLI_IMAGE" publish "$file" "${publish_args[@]}"
+            echo "::group::Publishing $file"
+            grcli publish "$file" "${publish_args[@]}"
             echo "::endgroup::"
           }
 

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -79,8 +79,9 @@ jobs:
       # Pinning note: grcli's own release CI uses this same tag and signs
       # keyless with --new-bundle-format successfully. SHA-pin before merge to
       # match this repo's action-pinning convention (dependabot will maintain it).
-      - name: Setup cosign
-        uses: sigstore/cosign-installer@v3
+      - uses: sigstore/cosign-installer@v4.1.2
+        with:
+          cosign-release: v3.1.1
 
       - name: Build baseline-compiler
         run: go build -C cmd/ -o ../baseline-compiler

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -1,0 +1,134 @@
+# SPDX-FileCopyrightText: Copyright 2026 The OSPS Baseline Authors
+# SPDX-License-Identifier: Apache-2.0
+---
+name: Publish to grc.store
+
+# Publishes the compiled OSPS Baseline ControlCatalog plus every MappingDocument
+# under baseline/mappings/ to the Gemara registry (https://hub.grc.store) using
+# grcli. Triggered automatically when a GitHub Release is published; also
+# runnable manually for testing (use the dry_run input to skip the network).
+#
+# Requirements:
+#   - Repository secret GRCLI_TOKEN: bearer token for the hub sync call.
+#     Obtain by running `grcli login` locally and copying the access token from
+#     ${XDG_DATA_HOME:-~/.local/share}/grcli/credentials.json, or by issuing a
+#     service-account token in the grc.store hub UI.
+#
+# Notes:
+#   - The OCI tag for each artifact is taken from the release tag (or the
+#     workflow_dispatch input on manual runs). It is NOT taken from the
+#     artifact's metadata.version because the catalog and mapping documents
+#     are still marked draft: true.
+#   - Signing is disabled (--no-sign). To enable cosign signing, add a
+#     COSIGN_KEY secret and pass --cosign-key (or remove --no-sign once grcli
+#     supports keyless Sigstore signing in CI).
+
+on:
+  release:
+    types: [published]
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: "OCI tag to publish under (defaults to release tag; required for manual runs)"
+        required: false
+        default: ""
+      dry_run:
+        description: "Dry-run: build OCI layouts locally without pushing to the registry"
+        type: boolean
+        default: true
+
+permissions:
+  contents: read
+
+jobs:
+  publish:
+    name: Publish baseline catalog and mappings
+    runs-on: ubuntu-latest
+    env:
+      GRCLI_IMAGE: ghcr.io/revanite-io/grcli:latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+
+      - name: Setup Go
+        uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
+        with:
+          go-version-file: cmd/go.mod
+          check-latest: true
+          cache: true
+
+      - name: Build baseline-compiler
+        run: go build -C cmd/ -o ../baseline-compiler
+
+      - name: Compile catalog to single Gemara YAML
+        run: ./baseline-compiler gemara -b baseline -o baseline.gemara.yaml
+
+      - name: Determine publish tag
+        id: tag
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          RELEASE_TAG: ${{ github.event.release.tag_name }}
+          INPUT_TAG: ${{ github.event.inputs.tag }}
+        run: |
+          set -euo pipefail
+          if [ "$EVENT_NAME" = "release" ]; then
+            tag="$RELEASE_TAG"
+          elif [ -n "$INPUT_TAG" ]; then
+            tag="$INPUT_TAG"
+          else
+            # Manual dispatch with no explicit tag: build a deterministic dev tag
+            # tied to the commit SHA. Only useful for dry-run publishing.
+            tag="v0.0.0-dev-${GITHUB_SHA:0:7}"
+          fi
+          if [ -z "$tag" ]; then
+            echo "::error::Unable to determine publish tag"
+            exit 1
+          fi
+          echo "tag=$tag" >> "$GITHUB_OUTPUT"
+          echo "Using publish tag: $tag"
+
+      - name: Pull grcli image
+        run: docker pull "$GRCLI_IMAGE"
+
+      - name: Publish catalog and mapping documents to grc.store
+        env:
+          GRCLI_TOKEN: ${{ secrets.GRCLI_TOKEN }}
+          PUBLISH_TAG: ${{ steps.tag.outputs.tag }}
+          DRY_RUN: ${{ github.event.inputs.dry_run }}
+        run: |
+          set -euo pipefail
+
+          publish_args=(--tag "$PUBLISH_TAG" --no-sign)
+          if [ "${DRY_RUN:-false}" = "true" ]; then
+            publish_args+=(--dry-run)
+            echo "Running in DRY-RUN mode (no network, OCI layout written under grcli-out/)"
+          elif [ -z "${GRCLI_TOKEN:-}" ]; then
+            echo "::error::GRCLI_TOKEN secret is not set; cannot publish to grc.store"
+            exit 1
+          fi
+
+          publish() {
+            local file="$1"
+            echo "::group::Publishing $file (tag=$PUBLISH_TAG)"
+            docker run --rm \
+              -v "$PWD:/workspace" -w /workspace \
+              -e GRCLI_TOKEN \
+              "$GRCLI_IMAGE" publish "$file" "${publish_args[@]}"
+            echo "::endgroup::"
+          }
+
+          publish baseline.gemara.yaml
+          for f in baseline/mappings/*.yaml; do
+            publish "$f"
+          done
+
+      - name: Upload dry-run OCI layouts
+        if: ${{ github.event.inputs.dry_run == 'true' }}
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: grcli-dry-run-layouts
+          path: grcli-out/
+          retention-days: 7
+          if-no-files-found: warn

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -4,10 +4,12 @@
 name: Publish to grc.store
 
 # Publishes the compiled OSPS Baseline ControlCatalog plus every MappingDocument
-# under baseline/mappings/ to the Gemara registry (https://hub.grc.store by
-# default) using grcli. Triggered automatically when a GitHub Release is
-# published; also runnable manually for testing (dry_run defaults to true, and
-# hub_url can point at preview).
+# under baseline/mappings/ to the grc.store PREVIEW hub using grcli. Triggered
+# automatically when a GitHub Release is published; also runnable manually
+# (dry_run defaults to true; version can be specified for the run).
+#
+# TEMPORARY: this targets preview.grc.store while we validate the pipeline.
+# Flip HUB_URL to https://hub.grc.store once everything is locked in.
 #
 # Auth:
 #   - grcli authenticates to grc.store via OIDC trusted publishing. The
@@ -37,10 +39,10 @@ on:
         description: "Dry-run: build OCI layouts locally without pushing to the registry"
         type: boolean
         default: true
-      hub_url:
-        description: "Hub base URL to publish to (e.g. https://hub.preview.grc.store for testing)"
+      version:
+        description: "Catalog version — the metadata.version stamped onto every artifact, and the OCI tag (e.g. v0.1.0). Defaults to a dev tag derived from the commit SHA if left blank."
         type: string
-        default: "https://hub.grc.store"
+        default: ""
 
 permissions:
   contents: read
@@ -112,26 +114,25 @@ jobs:
       - name: Publish catalog and mapping documents to grc.store
         env:
           DRY_RUN: ${{ github.event.inputs.dry_run }}
-          HUB_URL_INPUT: ${{ github.event.inputs.hub_url }}
+          VERSION_INPUT: ${{ github.event.inputs.version }}
           EVENT_NAME: ${{ github.event_name }}
           RELEASE_TAG: ${{ github.event.release.tag_name }}
         run: |
           set -euo pipefail
 
-          # Hub target: the dispatch input when set (lets a manual run point at
-          # preview), otherwise the production hub for release events.
-          HUB_URL="${HUB_URL_INPUT:-}"
-          if [ -z "$HUB_URL" ]; then
-            HUB_URL="https://hub.grc.store"
-          fi
+          # TEMPORARY: always target the preview hub while we validate the
+          # pipeline. Change this to https://hub.grc.store once locked in.
+          HUB_URL="https://hub.preview.grc.store"
           echo "Target hub: $HUB_URL"
 
           # Every artifact in a single release is stamped with the same
-          # metadata.version (and therefore the same OCI tag). On release
-          # events that's the release tag; on manual dry-runs it's a
-          # deterministic dev tag derived from the commit SHA.
+          # metadata.version (and therefore the same OCI tag). Resolution order:
+          # the release tag on release events; otherwise the version dispatch
+          # input; otherwise a deterministic dev tag derived from the commit SHA.
           if [ "$EVENT_NAME" = "release" ]; then
             RELEASE_VERSION="$RELEASE_TAG"
+          elif [ -n "${VERSION_INPUT:-}" ]; then
+            RELEASE_VERSION="$VERSION_INPUT"
           else
             RELEASE_VERSION="v0.0.0-dev-${GITHUB_SHA:0:7}"
           fi

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -146,7 +146,7 @@ jobs:
           # Real publishes are signed keyless (no flag needed — grcli detects
           # GitHub Actions + the id-token and drives cosign). Dry-runs skip the
           # network, so there is nothing to sign or push a signature to.
-          publish_args=(--url "$HUB_URL")
+          publish_args=(--url "$HUB_URL" --license Apache-2.0)
           if [ "${DRY_RUN:-false}" = "true" ]; then
             publish_args+=(--dry-run --no-sign)
             echo "Running in DRY-RUN mode (no network; OCI layouts under grcli-out/, unsigned)"

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -4,15 +4,18 @@
 name: Publish to grc.store
 
 # Publishes the compiled OSPS Baseline ControlCatalog plus every MappingDocument
-# under baseline/mappings/ to the Gemara registry (https://hub.grc.store) using
-# grcli. Triggered automatically when a GitHub Release is published; also
-# runnable manually for testing (dry_run defaults to true).
+# under baseline/mappings/ to the Gemara registry (https://hub.grc.store by
+# default) using grcli. Triggered automatically when a GitHub Release is
+# published; also runnable manually for testing (dry_run defaults to true, and
+# hub_url can point at preview).
 #
 # Auth:
 #   - grcli authenticates to grc.store via OIDC trusted publishing. The
 #     id-token: write permission below lets the runner mint an OIDC token
 #     that grcli exchanges for a hub credential. No static secrets needed —
-#     register this repo as a trusted publisher in the grc.store hub UI.
+#     register this repo as a trusted publisher in the grc.store hub for the
+#     target (openssf) namespace. A 403 at publish means that binding is
+#     missing, not that a secret is needed.
 #
 # Notes:
 #   - grcli is distributed as an OCI artifact (not a runnable container),
@@ -20,9 +23,10 @@ name: Publish to grc.store
 #   - The OCI tag for each artifact is the release tag. We stamp it onto
 #     each artifact's metadata.version at publish time so grcli's default
 #     tag resolution picks it up; the committed YAML files are untouched.
-#   - Signing is disabled (--no-sign). To enable cosign signing, add a
-#     COSIGN_KEY secret and pass --cosign-key (or remove --no-sign once grcli
-#     supports keyless Sigstore signing in CI).
+#   - Signing: grcli signs keyless via cosign automatically in GitHub Actions
+#     (it reads the GHA OIDC token; needs cosign on PATH + id-token: write).
+#     Real publishes are signed; dry-runs pass --no-sign since there is no
+#     registry to push a signature to.
 
 on:
   release:
@@ -33,6 +37,10 @@ on:
         description: "Dry-run: build OCI layouts locally without pushing to the registry"
         type: boolean
         default: true
+      hub_url:
+        description: "Hub base URL to publish to (e.g. https://hub.preview.grc.store for testing)"
+        type: string
+        default: "https://hub.grc.store"
 
 permissions:
   contents: read
@@ -58,14 +66,35 @@ jobs:
           check-latest: true
           cache: true
 
+      - name: Setup CUE
+        uses: cue-lang/setup-cue@a93fa358375740cd8b0078f76355512b9208acb1 # v1.0.1
+        with:
+          version: latest
+
       - name: Setup oras
         uses: oras-project/setup-oras@8d34698a59f5ffe24821f0b48ab62a3de8b64b20 # v1.2.3
+
+      # Pinning note: grcli's own release CI uses this same tag and signs
+      # keyless with --new-bundle-format successfully. SHA-pin before merge to
+      # match this repo's action-pinning convention (dependabot will maintain it).
+      - name: Setup cosign
+        uses: sigstore/cosign-installer@v3
 
       - name: Build baseline-compiler
         run: go build -C cmd/ -o ../baseline-compiler
 
       - name: Compile catalog to single Gemara YAML
         run: ./baseline-compiler gemara -b baseline -o baseline.gemara.yaml
+
+      - name: Validate catalog and mappings against CUE schema
+        run: |
+          set -euo pipefail
+          cd schema
+          cue vet -d '#OSPSBaseline' . ../baseline.gemara.yaml
+          for f in ../baseline/mappings/*.yaml; do
+            echo "vetting $f"
+            cue vet -d '#OSPSMapping' . "$f"
+          done
 
       - name: Install grcli from OCI artifact
         env:
@@ -83,10 +112,19 @@ jobs:
       - name: Publish catalog and mapping documents to grc.store
         env:
           DRY_RUN: ${{ github.event.inputs.dry_run }}
+          HUB_URL_INPUT: ${{ github.event.inputs.hub_url }}
           EVENT_NAME: ${{ github.event_name }}
           RELEASE_TAG: ${{ github.event.release.tag_name }}
         run: |
           set -euo pipefail
+
+          # Hub target: the dispatch input when set (lets a manual run point at
+          # preview), otherwise the production hub for release events.
+          HUB_URL="${HUB_URL_INPUT:-}"
+          if [ -z "$HUB_URL" ]; then
+            HUB_URL="https://hub.grc.store"
+          fi
+          echo "Target hub: $HUB_URL"
 
           # Every artifact in a single release is stamped with the same
           # metadata.version (and therefore the same OCI tag). On release
@@ -104,10 +142,13 @@ jobs:
           export RELEASE_VERSION
           echo "Publishing all artifacts as metadata.version=$RELEASE_VERSION"
 
-          publish_args=(--no-sign)
+          # Real publishes are signed keyless (no flag needed — grcli detects
+          # GitHub Actions + the id-token and drives cosign). Dry-runs skip the
+          # network, so there is nothing to sign or push a signature to.
+          publish_args=(--url "$HUB_URL")
           if [ "${DRY_RUN:-false}" = "true" ]; then
-            publish_args+=(--dry-run)
-            echo "Running in DRY-RUN mode (no network, OCI layout written under grcli-out/)"
+            publish_args+=(--dry-run --no-sign)
+            echo "Running in DRY-RUN mode (no network; OCI layouts under grcli-out/, unsigned)"
           fi
 
           staged="$RUNNER_TEMP/staged"

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -17,9 +17,9 @@ name: Publish to grc.store
 # Notes:
 #   - grcli is distributed as an OCI artifact (not a runnable container),
 #     so we fetch it with oras instead of docker pull.
-#   - The OCI tag for each artifact comes from the artifact's own
-#     metadata.version field. Make sure metadata.version is bumped and
-#     `draft: true` is cleared before cutting a release.
+#   - The OCI tag for each artifact is the release tag. We stamp it onto
+#     each artifact's metadata.version at publish time so grcli's default
+#     tag resolution picks it up; the committed YAML files are untouched.
 #   - Signing is disabled (--no-sign). To enable cosign signing, add a
 #     COSIGN_KEY secret and pass --cosign-key (or remove --no-sign once grcli
 #     supports keyless Sigstore signing in CI).
@@ -83,8 +83,26 @@ jobs:
         env:
           GRCLI_TOKEN: ${{ secrets.GRCLI_TOKEN }}
           DRY_RUN: ${{ github.event.inputs.dry_run }}
+          EVENT_NAME: ${{ github.event_name }}
+          RELEASE_TAG: ${{ github.event.release.tag_name }}
         run: |
           set -euo pipefail
+
+          # Every artifact in a single release is stamped with the same
+          # metadata.version (and therefore the same OCI tag). On release
+          # events that's the release tag; on manual dry-runs it's a
+          # deterministic dev tag derived from the commit SHA.
+          if [ "$EVENT_NAME" = "release" ]; then
+            RELEASE_VERSION="$RELEASE_TAG"
+          else
+            RELEASE_VERSION="v0.0.0-dev-${GITHUB_SHA:0:7}"
+          fi
+          if [ -z "$RELEASE_VERSION" ]; then
+            echo "::error::Could not determine release version"
+            exit 1
+          fi
+          export RELEASE_VERSION
+          echo "Publishing all artifacts as metadata.version=$RELEASE_VERSION"
 
           publish_args=(--no-sign)
           if [ "${DRY_RUN:-false}" = "true" ]; then
@@ -95,10 +113,17 @@ jobs:
             exit 1
           fi
 
+          staged="$RUNNER_TEMP/staged"
+          mkdir -p "$staged"
+
           publish() {
-            local file="$1"
-            echo "::group::Publishing $file"
-            grcli publish "$file" "${publish_args[@]}"
+            local src="$1"
+            local dst="$staged/$(basename "$src")"
+            # Stamp metadata.version with the resolved release version so grcli
+            # picks it up as the OCI tag (we never modify the committed source).
+            yq '.metadata.version = strenv(RELEASE_VERSION)' "$src" > "$dst"
+            echo "::group::Publishing $src"
+            grcli publish "$dst" "${publish_args[@]}"
             echo "::endgroup::"
           }
 

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -3,34 +3,11 @@
 ---
 name: Publish to grc.store
 
-# Publishes the compiled OSPS Baseline ControlCatalog plus every MappingDocument
-# under baseline/mappings/ to the grc.store hub using grcli. Triggered
-# automatically when a GitHub Release is published; also runnable manually
-# (dry_run defaults to true; version can be specified for the run).
-#
-# Auth:
-#   - grcli authenticates to grc.store via OIDC trusted publishing. The
-#     id-token: write permission below lets the runner mint an OIDC token
-#     that grcli exchanges for a hub credential. No static secrets needed —
-#     register this repo as a trusted publisher in the grc.store hub for the
-#     target (openssf) namespace. A 403 at publish means that binding is
-#     missing, not that a secret is needed.
-#
-# Notes:
-#   - grcli is distributed as an OCI artifact (not a runnable container),
-#     so we fetch it with oras instead of docker pull. Pin a released tag,
-#     never :latest — v0.5.1 shipped a broken signing path and anything
-#     tracking :latest inherited it. Note the upstream org move: v0.6.0+
-#     live at ghcr.io/gemaraproj/grcli, tags <= v0.5.1 at revanite-io.
-#   - The OCI tag for each artifact is the release tag. We stamp it onto
-#     each artifact's metadata.version at publish time so grcli's default
-#     tag resolution picks it up; the committed YAML files are untouched.
-#   - Signing: as of grcli v0.6.0 keyless signing runs in-process via
-#     sigstore-go — grcli mints the Actions OIDC token itself, gets a Fulcio
-#     certificate, logs to Rekor and attaches the signature as an OCI
-#     referrer. No cosign install step is needed (cosign is required only for
-#     the --cosign-key path, which we do not use). Real publishes are signed;
-#     dry-runs pass --no-sign since there is no registry to push a signature to.
+# Publishes the compiled ControlCatalog and every baseline/mappings/*.yaml to
+# grc.store. Auth is OIDC trusted publishing: `id-token: write` is the whole
+# setup, no secrets. A 403 means this repo is not yet registered as a trusted
+# publisher for the openssf namespace.
+# https://github.com/gemaraproj/grcli#publishing-from-github-actions
 
 on:
   release:
@@ -38,23 +15,35 @@ on:
   workflow_dispatch:
     inputs:
       dry_run:
-        description: "Dry-run: build OCI layouts locally without pushing to the registry"
+        description: "Build OCI layouts locally instead of pushing"
         type: boolean
         default: true
       version:
-        description: "Catalog version — the metadata.version stamped onto every artifact, and the OCI tag (e.g. v0.1.0). Defaults to a dev tag derived from the commit SHA if left blank."
+        description: "Version stamped on every artifact, and the OCI tag. Defaults to a dev tag from the commit SHA."
         type: string
-        default: ""
 
 permissions:
   contents: read
-  packages: read
   id-token: write
+
+defaults:
+  run:
+    shell: bash
 
 jobs:
   publish:
     name: Publish baseline catalog and mappings
     runs-on: ubuntu-latest
+    # Keyed on the target version, not the workflow: two runs publishing the
+    # same version must serialize, but two different releases must not queue
+    # against each other (a queued run gets cancelled when a third arrives).
+    concurrency:
+      group: publish-grc-store-${{ github.event.release.tag_name || inputs.version || github.sha }}
+      cancel-in-progress: false
+    env:
+      RELEASE_VERSION: ${{ github.event.release.tag_name || inputs.version || format('v0.0.0-dev-{0}', github.sha) }}
+      HUB_URL: https://hub.grc.store
+      DRY_RUN_FLAGS: ${{ inputs.dry_run && '--dry-run --no-sign' || '' }}
     steps:
       - name: Checkout
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
@@ -76,95 +65,42 @@ jobs:
       - name: Setup oras
         uses: oras-project/setup-oras@8d34698a59f5ffe24821f0b48ab62a3de8b64b20 # v1.2.3
 
-      - name: Build baseline-compiler
-        run: go build -C cmd/ -o ../baseline-compiler
+      - name: Compile catalog to a single Gemara YAML
+        run: |
+          go build -C cmd/ -o ../baseline-compiler
+          ./baseline-compiler gemara -b baseline -o baseline.gemara.yaml
 
-      - name: Compile catalog to single Gemara YAML
-        run: ./baseline-compiler gemara -b baseline -o baseline.gemara.yaml
-
+      # One `cue vet` per mapping: vetting them together would unify all 14 into
+      # a single instance instead of checking each on its own.
       - name: Validate catalog and mappings against CUE schema
         run: |
-          set -euo pipefail
           cd schema
           cue vet -d '#OSPSBaseline' . ../baseline.gemara.yaml
           for f in ../baseline/mappings/*.yaml; do
-            echo "vetting $f"
             cue vet -d '#OSPSMapping' . "$f"
           done
 
-      - name: Install grcli from OCI artifact
-        env:
-          GHCR_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - name: Install grcli
         run: |
-          set -euo pipefail
-          mkdir -p "$RUNNER_TEMP/bin"
-          echo "$GHCR_TOKEN" | oras login ghcr.io -u "${{ github.actor }}" --password-stdin
-          cd "$RUNNER_TEMP/bin"
-          oras pull --platform linux/amd64 ghcr.io/gemaraproj/grcli:v0.6.0
-          chmod +x grcli
-          echo "$RUNNER_TEMP/bin" >> "$GITHUB_PATH"
-          ./grcli --version
+          oras pull ghcr.io/gemaraproj/grcli@sha256:9e668b4a5a6bc93c48190f2495911e20276bbc3dff9d9e0b0de35a859b69ca5f --platform linux/amd64
+          sudo install grcli /usr/local/bin/grcli
 
+      # One grcli invocation per artifact: positional args to `publish` describe
+      # ONE artifact, they are not a batch. metadata.version is stamped onto a
+      # staged copy (grcli uses it as the OCI tag); committed YAML is untouched.
+      # Each artifact gets its own --output so dry-run layouts don't collide on
+      # the shared tag.
       - name: Publish catalog and mapping documents to grc.store
-        env:
-          DRY_RUN: ${{ github.event.inputs.dry_run }}
-          VERSION_INPUT: ${{ github.event.inputs.version }}
-          EVENT_NAME: ${{ github.event_name }}
-          RELEASE_TAG: ${{ github.event.release.tag_name }}
         run: |
-          set -euo pipefail
-
-          HUB_URL="https://hub.grc.store"
-          echo "Target hub: $HUB_URL"
-
-          # Every artifact in a single release is stamped with the same
-          # metadata.version (and therefore the same OCI tag). Resolution order:
-          # the release tag on release events; otherwise the version dispatch
-          # input; otherwise a deterministic dev tag derived from the commit SHA.
-          if [ "$EVENT_NAME" = "release" ]; then
-            RELEASE_VERSION="$RELEASE_TAG"
-          elif [ -n "${VERSION_INPUT:-}" ]; then
-            RELEASE_VERSION="$VERSION_INPUT"
-          else
-            RELEASE_VERSION="v0.0.0-dev-${GITHUB_SHA:0:7}"
-          fi
-          if [ -z "$RELEASE_VERSION" ]; then
-            echo "::error::Could not determine release version"
-            exit 1
-          fi
-          export RELEASE_VERSION
-          echo "Publishing all artifacts as metadata.version=$RELEASE_VERSION"
-
-          # Real publishes are signed keyless (no flag needed — grcli detects
-          # GitHub Actions + the id-token and signs in-process). Dry-runs skip
-          # the network, so there is nothing to sign or push a signature to.
-          publish_args=(--url "$HUB_URL" --license Apache-2.0)
-          if [ "${DRY_RUN:-false}" = "true" ]; then
-            publish_args+=(--dry-run --no-sign)
-            echo "Running in DRY-RUN mode (no network; OCI layouts under grcli-out/, unsigned)"
-          fi
-
-          staged="$RUNNER_TEMP/staged"
-          mkdir -p "$staged"
-
-          publish() {
-            local src="$1"
-            local dst="$staged/$(basename "$src")"
-            # Stamp metadata.version with the resolved release version so grcli
-            # picks it up as the OCI tag (we never modify the committed source).
-            yq '.metadata.version = strenv(RELEASE_VERSION)' "$src" > "$dst"
-            echo "::group::Publishing $src"
-            grcli publish "$dst" "${publish_args[@]}"
-            echo "::endgroup::"
-          }
-
-          publish baseline.gemara.yaml
-          for f in baseline/mappings/*.yaml; do
-            publish "$f"
+          for f in baseline.gemara.yaml baseline/mappings/*.yaml; do
+            name=$(basename "$f" .yaml)
+            yq '.metadata.version = strenv(RELEASE_VERSION)' "$f" > "$RUNNER_TEMP/$name.yaml"
+            grcli publish "$RUNNER_TEMP/$name.yaml" --url "$HUB_URL" --license Apache-2.0 \
+              --output "grcli-out/$name" $DRY_RUN_FLAGS
           done
 
       - name: Upload dry-run OCI layouts
-        if: ${{ github.event.inputs.dry_run == 'true' }}
+        if: ${{ inputs.dry_run }}
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: grcli-dry-run-layouts

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -4,12 +4,9 @@
 name: Publish to grc.store
 
 # Publishes the compiled OSPS Baseline ControlCatalog plus every MappingDocument
-# under baseline/mappings/ to the grc.store PREVIEW hub using grcli. Triggered
+# under baseline/mappings/ to the grc.store hub using grcli. Triggered
 # automatically when a GitHub Release is published; also runnable manually
 # (dry_run defaults to true; version can be specified for the run).
-#
-# TEMPORARY: this targets preview.grc.store while we validate the pipeline.
-# Flip HUB_URL to https://hub.grc.store once everything is locked in.
 #
 # Auth:
 #   - grcli authenticates to grc.store via OIDC trusted publishing. The
@@ -57,12 +54,12 @@ jobs:
       GRCLI_REF: ghcr.io/revanite-io/grcli:latest
     steps:
       - name: Checkout
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           persist-credentials: false
 
       - name: Setup Go
-        uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
+        uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6.5.0
         with:
           go-version-file: cmd/go.mod
           check-latest: true
@@ -76,10 +73,8 @@ jobs:
       - name: Setup oras
         uses: oras-project/setup-oras@8d34698a59f5ffe24821f0b48ab62a3de8b64b20 # v1.2.3
 
-      # Pinning note: grcli's own release CI uses this same tag and signs
-      # keyless with --new-bundle-format successfully. SHA-pin before merge to
-      # match this repo's action-pinning convention (dependabot will maintain it).
-      - uses: sigstore/cosign-installer@v4.1.2
+      - name: Setup cosign
+        uses: sigstore/cosign-installer@6f9f17788090df1f26f669e9d70d6ae9567deba6 # v4.1.2
         with:
           cosign-release: v3.1.1
 
@@ -121,9 +116,7 @@ jobs:
         run: |
           set -euo pipefail
 
-          # TEMPORARY: always target the preview hub while we validate the
-          # pipeline. Change this to https://hub.grc.store once locked in.
-          HUB_URL="https://hub.preview.grc.store"
+          HUB_URL="https://hub.grc.store"
           echo "Target hub: $HUB_URL"
 
           # Every artifact in a single release is stamped with the same

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -50,35 +50,13 @@ jobs:
         with:
           persist-credentials: false
 
-      - name: Setup Go
-        uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6.5.0
-        with:
-          go-version-file: cmd/go.mod
-          check-latest: true
-          cache: true
-
-      - name: Setup CUE
-        uses: cue-lang/setup-cue@a93fa358375740cd8b0078f76355512b9208acb1 # v1.0.1
-        with:
-          version: latest
+      # Shared with cue-validate.yaml — the CUE gate must not drift between the
+      # workflow that checks a PR and the one that publishes.
+      - name: Compile catalog and vet it against the CUE schema
+        uses: ./.github/actions/compile-and-vet
 
       - name: Setup oras
         uses: oras-project/setup-oras@8d34698a59f5ffe24821f0b48ab62a3de8b64b20 # v1.2.3
-
-      - name: Compile catalog to a single Gemara YAML
-        run: |
-          go build -C cmd/ -o ../baseline-compiler
-          ./baseline-compiler gemara -b baseline -o baseline.gemara.yaml
-
-      # One `cue vet` per mapping: vetting them together would unify all 14 into
-      # a single instance instead of checking each on its own.
-      - name: Validate catalog and mappings against CUE schema
-        run: |
-          cd schema
-          cue vet -d '#OSPSBaseline' . ../baseline.gemara.yaml
-          for f in ../baseline/mappings/*.yaml; do
-            cue vet -d '#OSPSMapping' . "$f"
-          done
 
       - name: Install grcli
         run: |

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -18,14 +18,19 @@ name: Publish to grc.store
 #
 # Notes:
 #   - grcli is distributed as an OCI artifact (not a runnable container),
-#     so we fetch it with oras instead of docker pull.
+#     so we fetch it with oras instead of docker pull. Pin a released tag,
+#     never :latest — v0.5.1 shipped a broken signing path and anything
+#     tracking :latest inherited it. Note the upstream org move: v0.6.0+
+#     live at ghcr.io/gemaraproj/grcli, tags <= v0.5.1 at revanite-io.
 #   - The OCI tag for each artifact is the release tag. We stamp it onto
 #     each artifact's metadata.version at publish time so grcli's default
 #     tag resolution picks it up; the committed YAML files are untouched.
-#   - Signing: grcli signs keyless via cosign automatically in GitHub Actions
-#     (it reads the GHA OIDC token; needs cosign on PATH + id-token: write).
-#     Real publishes are signed; dry-runs pass --no-sign since there is no
-#     registry to push a signature to.
+#   - Signing: as of grcli v0.6.0 keyless signing runs in-process via
+#     sigstore-go — grcli mints the Actions OIDC token itself, gets a Fulcio
+#     certificate, logs to Rekor and attaches the signature as an OCI
+#     referrer. No cosign install step is needed (cosign is required only for
+#     the --cosign-key path, which we do not use). Real publishes are signed;
+#     dry-runs pass --no-sign since there is no registry to push a signature to.
 
 on:
   release:
@@ -50,8 +55,6 @@ jobs:
   publish:
     name: Publish baseline catalog and mappings
     runs-on: ubuntu-latest
-    env:
-      GRCLI_REF: ghcr.io/revanite-io/grcli:latest
     steps:
       - name: Checkout
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
@@ -72,11 +75,6 @@ jobs:
 
       - name: Setup oras
         uses: oras-project/setup-oras@8d34698a59f5ffe24821f0b48ab62a3de8b64b20 # v1.2.3
-
-      - name: Setup cosign
-        uses: sigstore/cosign-installer@6f9f17788090df1f26f669e9d70d6ae9567deba6 # v4.1.2
-        with:
-          cosign-release: v3.1.1
 
       - name: Build baseline-compiler
         run: go build -C cmd/ -o ../baseline-compiler
@@ -102,7 +100,7 @@ jobs:
           mkdir -p "$RUNNER_TEMP/bin"
           echo "$GHCR_TOKEN" | oras login ghcr.io -u "${{ github.actor }}" --password-stdin
           cd "$RUNNER_TEMP/bin"
-          oras pull --platform linux/amd64 "$GRCLI_REF"
+          oras pull --platform linux/amd64 ghcr.io/gemaraproj/grcli:v0.6.0
           chmod +x grcli
           echo "$RUNNER_TEMP/bin" >> "$GITHUB_PATH"
           ./grcli --version
@@ -138,8 +136,8 @@ jobs:
           echo "Publishing all artifacts as metadata.version=$RELEASE_VERSION"
 
           # Real publishes are signed keyless (no flag needed — grcli detects
-          # GitHub Actions + the id-token and drives cosign). Dry-runs skip the
-          # network, so there is nothing to sign or push a signature to.
+          # GitHub Actions + the id-token and signs in-process). Dry-runs skip
+          # the network, so there is nothing to sign or push a signature to.
           publish_args=(--url "$HUB_URL" --license Apache-2.0)
           if [ "${DRY_RUN:-false}" = "true" ]; then
             publish_args+=(--dry-run --no-sign)


### PR DESCRIPTION
Adds `.github/workflows/publish.yaml`, which publishes the OSPS Baseline to [grc.store](https://grc.store) as versioned, signed OCI artifacts.

On a published GitHub Release it compiles the catalog with `baseline-compiler gemara`, CUE-vets the result and all 14 mapping documents, stamps each artifact's `metadata.version` from the release tag (staged copies — committed YAML is untouched), and publishes each one with `grcli`. Auth is OIDC trusted publishing: `id-token: write` is the whole setup, no secrets. Signing is keyless and happens in-process inside `grcli` via sigstore-go — there is no `cosign` install step, since `cosign` is only needed for the `--cosign-key` path we don't use.

Manual dispatch is also supported and defaults to a dry run, which builds the OCI layouts locally and uploads them as a build artifact.

### Also in this PR

- `.github/actions/compile-and-vet` — the build/compile/CUE-vet steps were duplicated verbatim between this workflow and `cue-validate.yaml`. Two copies of the CUE gate drift silently, and that gate is what stands between a bad mapping document and a signed publish, so both now call one composite action. `cue-validate.yaml` shrinks from 49 lines to 26.
- `.github/ISSUE_TEMPLATE/release.yaml` — the release checklist ended at "git tag the commit". The trigger here is `release: published`, so a bare tag would never have fired this workflow. Added the missing step.

### Before it can publish for real

Neither is a code change, so merging ahead of them is safe — an unregistered publisher just gets a 403:

1. Register `ossf/security-baseline` as an OIDC trusted publisher for the `openssf` namespace on hub.grc.store. All 15 artifacts carry `metadata.author.id: openssf` with distinct `metadata.id`, so one namespace binding covers `openssf/osps-baseline` and the 14 `openssf/osps-baseline-to-*` repositories.
2. Create an actual GitHub Release — see the checklist change above.

Suggested first run after merge: a manual dispatch with `dry_run` left at its default, to confirm the compile → CUE gate → layout pipeline end to end.

### Notes for reviewers

- **`grcli` is pinned by digest, not tag.** GHCR tags are mutable, and this is the one binary that executes holding an OIDC publishing credential.
- **The pull needs no credentials.** `ghcr.io/gemaraproj/grcli` is public. A raw unauthenticated request to ghcr.io returns 401, but that is the `WWW-Authenticate` challenge — ghcr.io issues anonymous pull tokens and `oras` follows the challenge automatically. Verified with a credential-free `oras pull` of the pinned digest.
- **One `grcli publish` per artifact, deliberately.** Positional args to `grcli publish` describe a *single* artifact, so batching all 15 into one call would produce one merged bundle rather than 15.
- **Each artifact gets its own `--output`.** `grcli`'s dry run writes an OCI layout tagged with `metadata.version` alone, with no repository component. Since every artifact in a release shares a version, a single shared output directory would leave only the last one addressable by tag.
- **One `cue vet` per mapping document, deliberately.** Vetting them together would unify all 14 into a single CUE instance instead of checking each on its own.
